### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,26 @@ COPY .cargo/config.toml            .cargo/config.toml
 COPY rpc-plane/Cargo.toml          rpc-plane/Cargo.toml
 COPY rpc-plane-core/Cargo.toml     rpc-plane-core/Cargo.toml
 COPY tools/dummy-rpc/Cargo.toml    tools/dummy-rpc/Cargo.toml
+COPY tools/load-test/Cargo.toml    tools/load-test/Cargo.toml
 
 # Stub sources so cargo can compile dependencies without the real code.
-RUN mkdir -p rpc-plane/src rpc-plane-core/src tools/dummy-rpc/src \
+# rpc-plane-core declares a `proxy_bench` bench (harness = false), so the
+# manifest won't parse unless benches/proxy_bench.rs exists too.
+RUN mkdir -p rpc-plane/src rpc-plane-core/src rpc-plane-core/benches tools/dummy-rpc/src tools/load-test/src \
  && echo 'fn main() {}' > rpc-plane/src/main.rs \
  && touch rpc-plane-core/src/lib.rs \
+ && echo 'fn main() {}' > rpc-plane-core/benches/proxy_bench.rs \
  && echo 'fn main() {}' > tools/dummy-rpc/src/main.rs \
+ && echo 'fn main() {}' > tools/load-test/src/main.rs \
  && cargo build --release -p rpc-plane \
- && rm -rf rpc-plane/src rpc-plane-core/src tools/dummy-rpc/src
+ && rm -rf rpc-plane/src rpc-plane-core/src rpc-plane-core/benches tools/dummy-rpc/src tools/load-test/src
 
 # Build the real binary.
-COPY rpc-plane/src       rpc-plane/src
-COPY rpc-plane-core/src  rpc-plane-core/src
+COPY rpc-plane/src           rpc-plane/src
+COPY rpc-plane-core/src      rpc-plane-core/src
+# Not compiled by `-p rpc-plane`, but the manifest declares the bench so the
+# file must exist for cargo to parse rpc-plane-core/Cargo.toml.
+COPY rpc-plane-core/benches  rpc-plane-core/benches
 # Embedded by `rpc-plane init` (include_str! at compile time).
 COPY config.example.toml config.example.toml
 


### PR DESCRIPTION

The dependency-cache stage hand-enumerates workspace members and now also workspace target files. Two additions broke `docker build`:

- `tools/load-test` (new workspace member) had no `COPY <m>/Cargo.toml` or stub src, so cargo failed to load the workspace manifest.
- `rpc-plane-core` declares `[[bench]] proxy_bench` (harness = false); cargo refuses to parse the manifest unless `benches/proxy_bench.rs` exists. This bit both the stub stage and the real-build stage (the stub cleanup rm -rf's the dir; the real-source section only COPYs src), so the bench is now stubbed in the RUN and the real file is COPYed back even though `-p rpc-plane` never compiles it.

Verified with a full local `docker build` (all 21 steps, exit 0).