### PR TITLE
docs: add CONTRIBUTING, CLA, and README badges

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,40 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write          # commit signatures to the signatures file
+  pull-requests: write     # comment on / label the PR
+  statuses: write          # set the CLA commit status
+
+jobs:
+  cla:
+    name: CLA signature check
+    runs-on: ubuntu-latest
+    # Skip the recheck path for unrelated comments to avoid needless runs.
+    if: >
+      github.event_name == 'pull_request_target' ||
+      github.event.comment.body == 'recheck' ||
+      github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+    steps:
+      - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A classic PAT (repo scope) or fine-grained PAT with Contents +
+          # Pull requests write. Required so signatures can be committed and
+          # the PR status re-checked. Create it under repo Settings →
+          # Secrets and variables → Actions as `CLA_SIGNATURES_TOKEN`.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          path-to-document: "https://github.com/rpcplane/rpc-plane/blob/main/CLA.md"
+          path-to-signatures: "signatures/version1/cla.json"
+          branch: "main"
+          # Bots never have copyrightable contributions; skip them.
+          allowlist: "dependabot[bot],renovate[bot],github-actions[bot]"
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          custom-allsigned-prcomment: "All contributors have signed the CLA. ✍️"

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,117 @@
+# RPC Plane Individual Contributor License Agreement
+
+Thank you for contributing to RPC Plane. This Contributor License Agreement
+("Agreement") clarifies the intellectual-property rights granted with
+Contributions from any person or entity. It protects you as a Contributor as
+well as the Project and its users; it does **not** change your right to use
+your own Contributions for any other purpose.
+
+> **Not legal advice.** This is a template adapted from the widely used
+> Apache-style individual CLA. Have it reviewed by counsel before relying
+> on it.
+
+You accept and agree to the following terms for your past, present, and future
+Contributions submitted to the Project. Except for the licenses granted here,
+you reserve all right, title, and interest in and to your Contributions.
+
+## 1. Definitions
+
+- **"Project"** means the RPC Plane software project hosted at
+  `https://github.com/rpcplane/rpc-plane`.
+- **"Project Owner"** means Pedro Gomes, together with his successors and
+  assigns — including any entity to which ownership of the Project is later
+  transferred or assigned.
+- **"You"** / **"Your"** means the individual or legal entity agreeing to this
+  Agreement. For a legal entity, the entity and all entities that control, are
+  controlled by, or are under common control with it are considered a single
+  Contributor.
+- **"Contribution"** means any original work of authorship, including any
+  modification to or addition to existing work, that is intentionally submitted
+  by You to the Project for inclusion in, or documentation of, the Project. For
+  this Agreement, "submitted" means any form of electronic, verbal, or written
+  communication sent to the Project or its maintainers — including but not
+  limited to pull requests, patches, issues, and discussion — excluding
+  communication conspicuously marked "Not a Contribution."
+
+## 2. Grant of copyright license
+
+Subject to the terms of this Agreement, You grant to the Project Owner and to
+recipients of software distributed by the Project Owner a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, **relicense**, and distribute Your Contributions and such
+derivative works. You acknowledge this includes the right for the Project Owner
+to license the Project, including Your Contributions, under the Elastic
+License 2.0, any later version of it, and/or other license terms (including
+commercial or proprietary terms), at the Project Owner's discretion.
+
+## 3. Grant of patent license
+
+Subject to the terms of this Agreement, You grant to the Project Owner and to
+recipients of software distributed by the Project Owner a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated in this section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer the Project, where such license applies
+only to those patent claims licensable by You that are necessarily infringed by
+Your Contribution alone or by combination of Your Contribution with the Project
+to which it was submitted. If any entity institutes patent litigation against
+You or any other entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that Your Contribution, or the Project to which You contributed,
+constitutes direct or contributory patent infringement, then any patent
+licenses granted to that entity under this Agreement for that Contribution or
+Project shall terminate as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses. If your employer has
+   rights to intellectual property that you create, you represent that you have
+   received permission to make Contributions on behalf of that employer, that
+   your employer has waived such rights for your Contributions to the Project,
+   or that your employer has executed a separate Corporate CLA with the Project
+   Owner.
+2. Each of Your Contributions is Your original creation (see Section 5 for
+   submissions that are not Your original creation).
+3. Your Contribution submissions include complete details of any third-party
+   license or other restriction (including related patents and trademarks) of
+   which you are personally aware and which are associated with any part of
+   Your Contributions.
+
+## 5. Third-party work
+
+Should You wish to submit work that is not Your original creation, You may
+submit it separately from any Contribution, identifying the complete details of
+its source and of any license or other restriction (including related patents,
+trademarks, and license agreements) of which you are personally aware, and
+conspicuously marking the work as "Submitted on behalf of a third party:
+[named here]".
+
+## 6. Support and warranties
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. Unless required by applicable law or
+agreed to in writing, You provide Your Contributions on an "AS IS" basis,
+without warranties or conditions of any kind, either express or implied,
+including any warranties or conditions of title, non-infringement,
+merchantability, or fitness for a particular purpose.
+
+## 7. Notification
+
+You agree to notify the Project Owner of any facts or circumstances of which
+you become aware that would make these representations inaccurate in any
+respect.
+
+---
+
+## How to sign
+
+This Agreement is administered through the **CLA Assistant** bot. When you open
+your first pull request, the bot comments with instructions. To sign, post the
+following as a comment on your pull request:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your GitHub username and the signing date are recorded in
+`signatures/version1/cla.json` in this repository. You only sign once; future
+pull requests are recognized automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to RPC Plane
+
+Thanks for your interest in improving RPC Plane. This is a small, focused
+codebase — contributions that keep it that way are the most welcome.
+
+## Before you start
+
+- **Bugs and features:** open an issue using the
+  [bug report](https://github.com/rpcplane/rpc-plane/issues/new?template=bug_report.yml)
+  or [feature request](https://github.com/rpcplane/rpc-plane/issues/new?template=feature_request.yml)
+  template. For anything non-trivial, please discuss it in an issue before
+  opening a PR so we can agree on the approach.
+- **Questions / usage help:** use
+  [Discussions](https://github.com/rpcplane/rpc-plane/discussions), not issues.
+- **Security vulnerabilities:** do **not** open a public issue. Follow
+  [SECURITY.md](SECURITY.md).
+
+## Development setup
+
+The toolchain is pinned in `rust-toolchain.toml` (currently Rust **1.91.1**);
+`rustup` will install it automatically when you build.
+
+```bash
+git clone https://github.com/rpcplane/rpc-plane
+cd rpc-plane
+cargo build
+cargo run -p rpc-plane -- --help
+```
+
+`tools/dummy-rpc` is a stub upstream you can point providers at for local
+testing, and `tools/load-test` drives synthetic traffic.
+
+## Before you open a PR
+
+CI runs these three checks and treats clippy warnings as errors. Run them
+locally first — they're exactly what the `Lint & Test` job runs:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+```
+
+## Pull requests
+
+- Keep PRs focused; one logical change per PR.
+- Add or update tests for behavior changes — most logic lives in
+  `rpc-plane-core` and is covered by unit/integration tests there.
+- Update `README.md`, `config.example.toml`, and the relevant `examples/`
+  configs when you add or change a config option.
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+  (`feat:`, `fix:`, `perf:`, `chore:`, `docs:`, …). Release notes are generated
+  from commit history, so clear messages matter.
+- Rebase on `main` and make sure the branch is green before requesting review.
+
+## Contributor License Agreement
+
+You'll sign the [CLA](CLA.md) on your first pull request — once, via the CLA
+Assistant bot. You keep ownership of your contributions; RPC Plane stays under
+the [Elastic License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # RPC Plane
 
+[![CI](https://github.com/rpcplane/rpc-plane/actions/workflows/ci.yml/badge.svg)](https://github.com/rpcplane/rpc-plane/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/rpcplane/rpc-plane?sort=semver)](https://github.com/rpcplane/rpc-plane/releases)
+[![License: Elastic-2.0](https://img.shields.io/badge/license-Elastic--2.0-blue.svg)](LICENSE)
+[![Docker](https://img.shields.io/badge/ghcr.io-rpcplane%2Frpc--plane-2496ED?logo=docker&logoColor=white)](https://github.com/rpcplane/rpc-plane/pkgs/container/rpc-plane)
+
 Solana RPC proxy with intelligent multi-provider routing, automatic failover, and slot-aware health scoring. A single binary that sits between your app and your RPC providers.
 
 ```


### PR DESCRIPTION
- README: CI / release / license / Docker badges
- CONTRIBUTING.md: dev setup, CI checks, PR guidelines, CLA pointer
- CLA.md: Apache-style individual CLA (Project Owner: Pedro Gomes, successors and assigns) with broad relicensing grant
- cla.yml: CLA Assistant workflow, action SHA-pinned to v2.6.1

Requires repo secret CLA_SIGNATURES_TOKEN (PAT) to be set before the CLA workflow can record signatures.