### PR TITLE
refactor: remove cost-aware routing from binary

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -26,8 +26,6 @@ w_success = 0.1
 # best_score | weighted_random | failover_ordered | parallel_race
 strategy         = "best_score"
 max_retries      = 2               # retry on next-best provider on transient errors
-cost_aware       = false
-cost_weight      = 0.2             # w_cost when cost_aware = true
 # broadcast_writes = false         # fan out sendTransaction to all providers
 
 # ── Providers ──────────────────────────────────────────────────────────────────

--- a/rpc-plane-core/benches/proxy_bench.rs
+++ b/rpc-plane-core/benches/proxy_bench.rs
@@ -27,7 +27,6 @@ fn prov(name: &str) -> ProviderConfig {
         name: name.to_string(),
         url: "http://localhost:9090".to_string(),
         weight: 1,
-        pricing: None,
         http3: false,
     }
 }

--- a/rpc-plane-core/src/config.rs
+++ b/rpc-plane-core/src/config.rs
@@ -205,10 +205,6 @@ pub struct RoutingConfig {
     /// Maximum provider retries on retryable errors (per request).
     #[serde(default = "default_max_retries")]
     pub max_retries: usize,
-    #[serde(default)]
-    pub cost_aware: bool,
-    #[serde(default = "default_cost_weight")]
-    pub cost_weight: f64,
     /// Broadcast sendTransaction / simulateTransaction to all healthy providers
     /// simultaneously. Off by default — writes are routed like reads.
     #[serde(default)]
@@ -220,8 +216,6 @@ impl Default for RoutingConfig {
         Self {
             strategy: RoutingStrategy::default(),
             max_retries: default_max_retries(),
-            cost_aware: false,
-            cost_weight: default_cost_weight(),
             broadcast_writes: false,
         }
     }
@@ -229,9 +223,6 @@ impl Default for RoutingConfig {
 
 fn default_max_retries() -> usize {
     2
-}
-fn default_cost_weight() -> f64 {
-    0.2
 }
 
 // ── Providers ───────────────────────────────────────────────────────────────
@@ -242,7 +233,6 @@ pub struct ProviderConfig {
     pub url: String,
     #[serde(default = "default_weight")]
     pub weight: u32,
-    pub pricing: Option<ProviderPricing>,
     /// Use HTTP/3 (QUIC) for outbound connections to this provider.
     #[serde(default)]
     pub http3: bool,
@@ -250,12 +240,6 @@ pub struct ProviderConfig {
 
 fn default_weight() -> u32 {
     1
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct ProviderPricing {
-    pub model: String,
-    pub monthly_budget_usd: Option<f64>,
 }
 
 // ── Reporting ────────────────────────────────────────────────────────────────

--- a/rpc-plane-core/src/health.rs
+++ b/rpc-plane-core/src/health.rs
@@ -688,7 +688,6 @@ mod tests {
             name: "p".to_string(),
             url: "http://127.0.0.1:1".to_string(),
             weight: 1,
-            pricing: None,
             http3: false,
         };
         let monitor = HealthMonitor::new(
@@ -719,7 +718,6 @@ mod tests {
             name: "test".to_string(),
             url: "http://localhost:8899".to_string(),
             weight: 1,
-            pricing: None,
             http3: false,
         };
         // We don't call add_provider here (needs real HTTP) — just verify map ops

--- a/rpc-plane-core/src/proxy.rs
+++ b/rpc-plane-core/src/proxy.rs
@@ -296,7 +296,6 @@ async fn sequential(
                     latency_ms,
                     status: "ok".to_string(),
                     commitment: None,
-
                 });
                 state.monitor.record(name, true, latency_ms);
                 return (
@@ -325,7 +324,6 @@ async fn sequential(
                     latency_ms,
                     status: "error".to_string(),
                     commitment: None,
-
                 });
                 state.monitor.record(name, false, latency_ms);
                 prev_failed = Some((name.clone(), "provider_error"));
@@ -397,7 +395,6 @@ async fn broadcast(
                     latency_ms,
                     status: "ok".to_string(),
                     commitment: None,
-
                 });
                 state.monitor.record(&name, true, latency_ms);
                 if first_success.is_none() {
@@ -423,7 +420,6 @@ async fn broadcast(
                     latency_ms,
                     status: "error".to_string(),
                     commitment: None,
-
                 });
                 state.monitor.record(&name, false, latency_ms);
             }

--- a/rpc-plane-core/src/proxy.rs
+++ b/rpc-plane-core/src/proxy.rs
@@ -274,7 +274,6 @@ async fn sequential(
                             latency_ms,
                             status: "error".to_string(),
                             commitment: None,
-                            estimated_cost: None,
                         });
                         state.monitor.record(name, false, latency_ms);
                         prev_failed = Some((name.clone(), "retryable_rpc_error"));
@@ -297,7 +296,7 @@ async fn sequential(
                     latency_ms,
                     status: "ok".to_string(),
                     commitment: None,
-                    estimated_cost: None,
+
                 });
                 state.monitor.record(name, true, latency_ms);
                 return (
@@ -326,7 +325,7 @@ async fn sequential(
                     latency_ms,
                     status: "error".to_string(),
                     commitment: None,
-                    estimated_cost: None,
+
                 });
                 state.monitor.record(name, false, latency_ms);
                 prev_failed = Some((name.clone(), "provider_error"));
@@ -398,7 +397,7 @@ async fn broadcast(
                     latency_ms,
                     status: "ok".to_string(),
                     commitment: None,
-                    estimated_cost: None,
+
                 });
                 state.monitor.record(&name, true, latency_ms);
                 if first_success.is_none() {
@@ -424,7 +423,7 @@ async fn broadcast(
                     latency_ms,
                     status: "error".to_string(),
                     commitment: None,
-                    estimated_cost: None,
+
                 });
                 state.monitor.record(&name, false, latency_ms);
             }

--- a/rpc-plane-core/src/router.rs
+++ b/rpc-plane-core/src/router.rs
@@ -222,7 +222,6 @@ mod tests {
                 name: n.to_string(),
                 url: "http://x".to_string(),
                 weight: 1,
-                pricing: None,
                 http3: false,
             })
             .collect()

--- a/rpc-plane-core/src/telemetry.rs
+++ b/rpc-plane-core/src/telemetry.rs
@@ -20,8 +20,6 @@ pub enum TelemetryEvent {
         status: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         commitment: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        estimated_cost: Option<f64>,
     },
     ProviderHealth {
         provider: String,
@@ -45,11 +43,6 @@ pub enum TelemetryEvent {
     CacheEvent {
         method: String,
         hit: bool,
-    },
-    BudgetAlert {
-        provider: String,
-        projected_usd: f64,
-        cap_usd: f64,
     },
 }
 
@@ -243,7 +236,6 @@ mod tests {
             latency_ms: 12.5,
             status: "ok".into(),
             commitment: None,
-            estimated_cost: None,
         });
         reporter.flush();
 
@@ -273,7 +265,6 @@ mod tests {
             latency_ms: 1.0,
             status: "ok".into(),
             commitment: None,
-            estimated_cost: None,
         };
         let json = serde_json::to_value(&ev).unwrap();
         assert!(json.get("commitment").is_none());

--- a/rpc-plane-core/tests/integration.rs
+++ b/rpc-plane-core/tests/integration.rs
@@ -72,7 +72,6 @@ fn test_config(
                 name: name.to_string(),
                 url: url.to_string(),
                 weight: 1,
-                pricing: None,
                 http3: false,
             })
             .collect(),
@@ -450,14 +449,12 @@ async fn circuit_recovers_traffic_resumes() {
                 name: "a".into(),
                 url: url_a,
                 weight: 1,
-                pricing: None,
                 http3: false,
             },
             ProviderConfig {
                 name: "b".into(),
                 url: url_b,
                 weight: 1,
-                pricing: None,
                 http3: false,
             },
         ],


### PR DESCRIPTION
## Summary

- Removes `cost_aware`, `cost_weight` from `RoutingConfig` and config files
- Removes `ProviderPricing` struct and `pricing` field from `ProviderConfig`
- Removes `estimated_cost` from `TelemetryEvent::Request`
- Removes `BudgetAlert` telemetry event

Cost routing belongs in the dashboard, not the binary. Provider pricing tables change frequently and can't be accurately maintained in a static binary config — especially for customers with negotiated discounts or dedicated tiers. The dashboard will maintain canonical per-method pricing for known providers and push cost routing rules to the binary via the config push channel.

For the common dedicated + metered fallback case, provider `weight` already handles priority without any cost tracking needed.

`cargo clippy` and `cargo test --all` pass.