### PR TITLE
refactor: remove cost routing, add request telemetry aggregation

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -51,6 +51,6 @@ http3  = true
 # [reporting]
 # endpoint          = "http://localhost:3000/api/ingest"
 # api_key           = "rp_live_xxxx"
-# flush_interval_ms = 5000   # how often to POST batched events
+# flush_interval_ms = 60000  # aggregate window + POST interval (ms)
 # buffer_size       = 1000   # max buffered events (oldest dropped when full)
 # batch_size        = 100    # max events per HTTP POST

--- a/rpc-plane-core/src/config.rs
+++ b/rpc-plane-core/src/config.rs
@@ -40,6 +40,12 @@ impl Config {
                 !r.endpoint.is_empty(),
                 "reporting.endpoint must not be empty"
             );
+            anyhow::ensure!(
+                r.flush_interval_ms >= 10_000,
+                "reporting.flush_interval_ms must be >= 10000 (10 s); got {}. \
+                 Values below 10 s produce excessive telemetry volume.",
+                r.flush_interval_ms
+            );
         }
         Ok(())
     }
@@ -265,7 +271,7 @@ pub struct ReportingConfig {
 }
 
 fn default_flush_interval_ms() -> u64 {
-    5000
+    60_000
 }
 fn default_buffer_size() -> usize {
     1000
@@ -398,7 +404,7 @@ api_key = "rp_live_test"
         let r = cfg.reporting.expect("reporting should be present");
         assert_eq!(r.endpoint, "http://localhost:3000/api/ingest");
         assert_eq!(r.api_key.as_deref(), Some("rp_live_test"));
-        assert_eq!(r.flush_interval_ms, 5000);
+        assert_eq!(r.flush_interval_ms, 60_000);
         assert_eq!(r.buffer_size, 1000);
         assert_eq!(r.batch_size, 100);
     }
@@ -422,6 +428,22 @@ endpoint = ""
 "#,
         );
         assert!(Config::load(f.path()).is_err());
+    }
+
+    #[test]
+    fn rejects_flush_interval_below_floor() {
+        let f = write_config(
+            r#"
+[[providers]]
+name = "p"
+url = "http://localhost:8899"
+[reporting]
+endpoint = "http://localhost:3000/api/ingest"
+flush_interval_ms = 1000
+"#,
+        );
+        let err = Config::load(f.path()).unwrap_err();
+        assert!(err.to_string().contains("flush_interval_ms"), "{err}");
     }
 
     #[test]

--- a/rpc-plane-core/src/health.rs
+++ b/rpc-plane-core/src/health.rs
@@ -1,7 +1,6 @@
 use crate::config::{HealthConfig, ProviderConfig};
 use crate::metrics::Metrics;
 use crate::proxy::Clients;
-use crate::telemetry::{NoopReporter, Reporter, TelemetryEvent};
 use parking_lot::RwLock;
 use reqwest::Client;
 use serde_json::Value;
@@ -250,20 +249,10 @@ pub struct HealthMonitor {
     entries: Arc<RwLock<HashMap<String, ProviderEntry>>>,
     pub cfg: Arc<HealthConfig>,
     metrics: Metrics,
-    reporter: Arc<dyn Reporter>,
 }
 
 impl HealthMonitor {
     pub fn new(providers: &[ProviderConfig], cfg: HealthConfig, metrics: Metrics) -> Self {
-        Self::new_with_reporter(providers, cfg, metrics, Arc::new(NoopReporter))
-    }
-
-    pub fn new_with_reporter(
-        providers: &[ProviderConfig],
-        cfg: HealthConfig,
-        metrics: Metrics,
-        reporter: Arc<dyn Reporter>,
-    ) -> Self {
         let entries = providers
             .iter()
             .map(|p| {
@@ -280,7 +269,6 @@ impl HealthMonitor {
             entries: Arc::new(RwLock::new(entries)),
             cfg: Arc::new(cfg),
             metrics,
-            reporter,
         }
     }
 
@@ -308,7 +296,6 @@ impl HealthMonitor {
                 provider,
                 self.cfg.clone(),
                 self.metrics.clone(),
-                self.reporter.clone(),
             );
         }
     }
@@ -324,7 +311,6 @@ impl HealthMonitor {
             provider.clone(),
             self.cfg.clone(),
             self.metrics.clone(),
-            self.reporter.clone(),
         );
         self.entries
             .write()
@@ -345,10 +331,9 @@ impl HealthMonitor {
         provider: ProviderConfig,
         cfg: Arc<HealthConfig>,
         metrics: Metrics,
-        reporter: Arc<dyn Reporter>,
     ) {
         tokio::spawn({
-            async move { health_loop(health, client, provider, cfg, metrics, reporter, stop).await }
+            async move { health_loop(health, client, provider, cfg, metrics, stop).await }
         });
     }
 
@@ -415,7 +400,6 @@ async fn health_loop(
     provider: ProviderConfig,
     cfg: Arc<HealthConfig>,
     metrics: Metrics,
-    reporter: Arc<dyn Reporter>,
     stop: Arc<AtomicBool>,
 ) {
     let interval = Duration::from_millis(cfg.interval_ms);
@@ -444,19 +428,6 @@ async fn health_loop(
                 warn!(provider = %provider.name, error = %e, "health probe failed");
             }
         }
-        // Emit telemetry snapshot after every probe regardless of outcome.
-        let snap = state.snapshot(0, &cfg);
-        reporter.emit(TelemetryEvent::ProviderHealth {
-            provider: provider.name.clone(),
-            score: snap.score,
-            slot_height: snap.slot_height,
-            slot_drift: snap.slot_drift,
-            circuit_state: match snap.circuit {
-                CircuitState::Closed => "closed".to_string(),
-                CircuitState::HalfOpen => "half_open".to_string(),
-                CircuitState::Open => "open".to_string(),
-            },
-        });
         if stop.load(Ordering::Relaxed) {
             break;
         }

--- a/rpc-plane-core/src/proxy.rs
+++ b/rpc-plane-core/src/proxy.rs
@@ -70,12 +70,7 @@ impl ProxyState {
     pub fn new_with_reporter(config: Config, reporter: Arc<dyn Reporter>) -> Self {
         let clients = build_clients(&config.providers, config.server.pool_max_idle_per_host);
         let metrics = Metrics::new();
-        let monitor = HealthMonitor::new_with_reporter(
-            &config.providers,
-            config.health.clone(),
-            metrics.clone(),
-            reporter.clone(),
-        );
+        let monitor = HealthMonitor::new(&config.providers, config.health.clone(), metrics.clone());
         monitor.start(clients.clone(), config.providers.clone());
         Self {
             config: Arc::new(parking_lot::RwLock::new(Arc::new(config))),
@@ -267,14 +262,9 @@ async fn sequential(
                         state
                             .metrics
                             .record_request(method, name, "error", latency_ms);
-                        state.reporter.emit(TelemetryEvent::Request {
-                            id: request_id.to_string(),
-                            method: method.to_string(),
-                            provider: name.to_string(),
-                            latency_ms,
-                            status: "error".to_string(),
-                            commitment: None,
-                        });
+                        state
+                            .reporter
+                            .record_request(method, name, "error", latency_ms);
                         state.monitor.record(name, false, latency_ms);
                         prev_failed = Some((name.clone(), "retryable_rpc_error"));
                         continue;
@@ -289,14 +279,9 @@ async fn sequential(
                     "request ok"
                 );
                 state.metrics.record_request(method, name, "ok", latency_ms);
-                state.reporter.emit(TelemetryEvent::Request {
-                    id: request_id.to_string(),
-                    method: method.to_string(),
-                    provider: name.to_string(),
-                    latency_ms,
-                    status: "ok".to_string(),
-                    commitment: None,
-                });
+                state
+                    .reporter
+                    .record_request(method, name, "ok", latency_ms);
                 state.monitor.record(name, true, latency_ms);
                 return (
                     StatusCode::OK,
@@ -317,14 +302,9 @@ async fn sequential(
                 state
                     .metrics
                     .record_request(method, name, "error", latency_ms);
-                state.reporter.emit(TelemetryEvent::Request {
-                    id: request_id.to_string(),
-                    method: method.to_string(),
-                    provider: name.to_string(),
-                    latency_ms,
-                    status: "error".to_string(),
-                    commitment: None,
-                });
+                state
+                    .reporter
+                    .record_request(method, name, "error", latency_ms);
                 state.monitor.record(name, false, latency_ms);
                 prev_failed = Some((name.clone(), "provider_error"));
             }
@@ -388,14 +368,9 @@ async fn broadcast(
                 state
                     .metrics
                     .record_request(method, &name, "ok", latency_ms);
-                state.reporter.emit(TelemetryEvent::Request {
-                    id: request_id.to_string(),
-                    method: method.to_string(),
-                    provider: name.to_string(),
-                    latency_ms,
-                    status: "ok".to_string(),
-                    commitment: None,
-                });
+                state
+                    .reporter
+                    .record_request(method, &name, "ok", latency_ms);
                 state.monitor.record(&name, true, latency_ms);
                 if first_success.is_none() {
                     info!(
@@ -413,14 +388,9 @@ async fn broadcast(
                 state
                     .metrics
                     .record_request(method, &name, "error", latency_ms);
-                state.reporter.emit(TelemetryEvent::Request {
-                    id: request_id.to_string(),
-                    method: method.to_string(),
-                    provider: name.to_string(),
-                    latency_ms,
-                    status: "error".to_string(),
-                    commitment: None,
-                });
+                state
+                    .reporter
+                    .record_request(method, &name, "error", latency_ms);
                 state.monitor.record(&name, false, latency_ms);
             }
             Err(e) => {

--- a/rpc-plane-core/src/telemetry.rs
+++ b/rpc-plane-core/src/telemetry.rs
@@ -1,8 +1,9 @@
 use crate::config::ReportingConfig;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use std::time::Duration;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{mpsc, Notify};
 use tracing::{debug, warn};
 
@@ -11,15 +12,21 @@ use tracing::{debug, warn};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TelemetryEvent {
-    Request {
-        id: String,
+    /// Pre-aggregated request stats for one (method, provider, status) bucket
+    /// covering a single flush window. Replaces per-request events to keep
+    /// Analytics Engine write volume independent of RPS.
+    RequestAggregate {
+        window_start_ms: u64,
+        window_end_ms: u64,
         method: String,
         provider: String,
-        latency_ms: f64,
         /// "ok" | "error"
         status: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        commitment: Option<String>,
+        count: u64,
+        latency_p50_ms: f64,
+        latency_p95_ms: f64,
+        latency_p99_ms: f64,
+        latency_avg_ms: f64,
     },
     ProviderHealth {
         provider: String,
@@ -40,18 +47,17 @@ pub enum TelemetryEvent {
         providers: Vec<(String, u64)>,
         resolution: String,
     },
-    CacheEvent {
-        method: String,
-        hit: bool,
-    },
 }
 
 // ── Reporter trait ────────────────────────────────────────────────────────────
 
 pub trait Reporter: Send + Sync {
-    /// Emit an event. Must never block the caller — implementations that do
-    /// async work must buffer internally.
+    /// Emit a raw event (Failover, Divergence, ProviderHealth). Must never block.
     fn emit(&self, event: TelemetryEvent);
+
+    /// Record a single request outcome into the aggregate accumulator.
+    /// Default implementation is a no-op (used by NoopReporter).
+    fn record_request(&self, _method: &str, _provider: &str, _status: &str, _latency_ms: f64) {}
 
     /// Signal the reporter to flush any buffered events. Fire-and-forget.
     fn flush(&self);
@@ -67,16 +73,98 @@ impl Reporter for NoopReporter {
     fn flush(&self) {}
 }
 
+// ── Aggregator ────────────────────────────────────────────────────────────────
+
+/// Accumulates per-request latency samples into (method, provider, status) buckets.
+/// Drained at each flush interval to produce `RequestAggregate` events.
+struct Aggregator {
+    state: Mutex<AggState>,
+}
+
+struct AggState {
+    // key: (method, provider, status)
+    buckets: HashMap<(String, String, String), Vec<f64>>,
+    window_start_ms: u64,
+}
+
+impl Aggregator {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(AggState {
+                buckets: HashMap::new(),
+                window_start_ms: now_ms(),
+            }),
+        }
+    }
+
+    fn record(&self, method: &str, provider: &str, status: &str, latency_ms: f64) {
+        let mut s = self.state.lock().unwrap();
+        s.buckets
+            .entry((method.to_string(), provider.to_string(), status.to_string()))
+            .or_default()
+            .push(latency_ms);
+    }
+
+    /// Drain all buckets into `RequestAggregate` events and reset the window.
+    fn drain(&self) -> Vec<TelemetryEvent> {
+        let now = now_ms();
+        let mut s = self.state.lock().unwrap();
+        let window_start = s.window_start_ms;
+
+        let events = s
+            .buckets
+            .drain()
+            .filter(|(_, v)| !v.is_empty())
+            .map(|((method, provider, status), mut latencies)| {
+                let sum: f64 = latencies.iter().sum();
+                let count = latencies.len() as u64;
+                let latency_avg_ms = sum / count as f64;
+                latencies.sort_unstable_by(|a, b| a.total_cmp(b));
+                TelemetryEvent::RequestAggregate {
+                    window_start_ms: window_start,
+                    window_end_ms: now,
+                    method,
+                    provider,
+                    status,
+                    count,
+                    latency_p50_ms: percentile(&latencies, 50.0),
+                    latency_p95_ms: percentile(&latencies, 95.0),
+                    latency_p99_ms: percentile(&latencies, 99.0),
+                    latency_avg_ms,
+                }
+            })
+            .collect();
+
+        s.window_start_ms = now;
+        events
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    // nearest-rank: rank = ceil(p/100 * n), 1-indexed → 0-indexed = rank - 1
+    let rank = ((p / 100.0) * sorted.len() as f64).ceil() as usize;
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
 // ── RemoteReporter ────────────────────────────────────────────────────────────
 
-/// Buffers events in a bounded channel and flushes batches to a remote endpoint
-/// on a configurable interval or when the buffer reaches `batch_size`.
-///
-/// `emit` is always non-blocking: if the channel is full the event is silently
-/// dropped rather than stalling the proxy hot path.
+/// Buffers raw events in a bounded channel and aggregates request data in-memory.
+/// At each flush interval: drains the aggregator (producing `RequestAggregate` events)
+/// and sends all buffered events to the remote endpoint in batches.
 pub struct RemoteReporter {
     tx: mpsc::Sender<TelemetryEvent>,
     flush_signal: Arc<Notify>,
+    aggregator: Arc<Aggregator>,
 }
 
 impl RemoteReporter {
@@ -84,10 +172,21 @@ impl RemoteReporter {
     pub fn new(config: ReportingConfig, client: Arc<Client>) -> Self {
         let (tx, rx) = mpsc::channel(config.buffer_size);
         let flush_signal = Arc::new(Notify::new());
+        let aggregator = Arc::new(Aggregator::new());
 
-        tokio::spawn(flush_task(rx, flush_signal.clone(), config, client));
+        tokio::spawn(flush_task(
+            rx,
+            flush_signal.clone(),
+            aggregator.clone(),
+            config,
+            client,
+        ));
 
-        Self { tx, flush_signal }
+        Self {
+            tx,
+            flush_signal,
+            aggregator,
+        }
     }
 }
 
@@ -95,6 +194,10 @@ impl Reporter for RemoteReporter {
     fn emit(&self, event: TelemetryEvent) {
         // try_send never blocks; silently drop if the buffer is full.
         let _ = self.tx.try_send(event);
+    }
+
+    fn record_request(&self, method: &str, provider: &str, status: &str, latency_ms: f64) {
+        self.aggregator.record(method, provider, status, latency_ms);
     }
 
     fn flush(&self) {
@@ -107,6 +210,7 @@ impl Reporter for RemoteReporter {
 async fn flush_task(
     mut rx: mpsc::Receiver<TelemetryEvent>,
     flush_signal: Arc<Notify>,
+    aggregator: Arc<Aggregator>,
     config: ReportingConfig,
     client: Arc<Client>,
 ) {
@@ -129,12 +233,16 @@ async fn flush_task(
                 }
             }
             _ = interval.tick() => {
+                batch.extend(aggregator.drain());
+                while let Ok(e) = rx.try_recv() {
+                    batch.push(e);
+                }
                 if !batch.is_empty() {
                     send_batch(&client, &config, &mut batch).await;
                 }
             }
             _ = flush_signal.notified() => {
-                // Drain everything currently in the channel then send.
+                batch.extend(aggregator.drain());
                 while let Ok(e) = rx.try_recv() {
                     batch.push(e);
                 }
@@ -146,6 +254,7 @@ async fn flush_task(
     }
 
     // Final drain after the channel is closed (graceful shutdown).
+    batch.extend(aggregator.drain());
     while let Ok(e) = rx.try_recv() {
         batch.push(e);
     }
@@ -191,24 +300,40 @@ mod tests {
 
     struct RecordingReporter {
         events: Arc<Mutex<Vec<TelemetryEvent>>>,
+        requests: Arc<Mutex<Vec<(String, String, String, f64)>>>,
         flush_count: Arc<AtomicUsize>,
     }
 
     impl RecordingReporter {
-        fn new() -> (Self, Arc<Mutex<Vec<TelemetryEvent>>>, Arc<AtomicUsize>) {
+        fn new() -> (
+            Self,
+            Arc<Mutex<Vec<TelemetryEvent>>>,
+            Arc<Mutex<Vec<(String, String, String, f64)>>>,
+            Arc<AtomicUsize>,
+        ) {
             let events = Arc::new(Mutex::new(Vec::new()));
+            let requests = Arc::new(Mutex::new(Vec::new()));
             let flush_count = Arc::new(AtomicUsize::new(0));
             let reporter = Self {
                 events: events.clone(),
+                requests: requests.clone(),
                 flush_count: flush_count.clone(),
             };
-            (reporter, events, flush_count)
+            (reporter, events, requests, flush_count)
         }
     }
 
     impl Reporter for RecordingReporter {
         fn emit(&self, event: TelemetryEvent) {
             self.events.lock().unwrap().push(event);
+        }
+        fn record_request(&self, method: &str, provider: &str, status: &str, latency_ms: f64) {
+            self.requests.lock().unwrap().push((
+                method.to_string(),
+                provider.to_string(),
+                status.to_string(),
+                latency_ms,
+            ));
         }
         fn flush(&self) {
             self.flush_count.fetch_add(1, Ordering::Relaxed);
@@ -218,29 +343,29 @@ mod tests {
     #[test]
     fn noop_reporter_is_zero_cost() {
         let r = NoopReporter;
-        r.emit(TelemetryEvent::CacheEvent {
-            method: "getSlot".into(),
-            hit: true,
+        r.emit(TelemetryEvent::Failover {
+            from_provider: "a".into(),
+            to_provider: "b".into(),
+            reason: "test".into(),
         });
+        r.record_request("getSlot", "helius", "ok", 1.0);
         r.flush();
         // no panic = pass
     }
 
     #[test]
     fn recording_reporter_captures_events() {
-        let (reporter, events, flush_count) = RecordingReporter::new();
-        reporter.emit(TelemetryEvent::Request {
-            id: "abc".into(),
-            method: "getSlot".into(),
-            provider: "helius".into(),
-            latency_ms: 12.5,
-            status: "ok".into(),
-            commitment: None,
+        let (reporter, events, requests, flush_count) = RecordingReporter::new();
+        reporter.emit(TelemetryEvent::Failover {
+            from_provider: "a".into(),
+            to_provider: "b".into(),
+            reason: "test".into(),
         });
+        reporter.record_request("getSlot", "helius", "ok", 12.5);
         reporter.flush();
 
-        let locked = events.lock().unwrap();
-        assert_eq!(locked.len(), 1);
+        assert_eq!(events.lock().unwrap().len(), 1);
+        assert_eq!(requests.lock().unwrap().len(), 1);
         assert_eq!(flush_count.load(Ordering::Relaxed), 1);
     }
 
@@ -257,17 +382,72 @@ mod tests {
     }
 
     #[test]
-    fn request_event_skips_none_fields() {
-        let ev = TelemetryEvent::Request {
-            id: "x".into(),
+    fn request_aggregate_serializes_correctly() {
+        let ev = TelemetryEvent::RequestAggregate {
+            window_start_ms: 1000,
+            window_end_ms: 61000,
             method: "getSlot".into(),
-            provider: "p".into(),
-            latency_ms: 1.0,
+            provider: "helius".into(),
             status: "ok".into(),
-            commitment: None,
+            count: 5000,
+            latency_p50_ms: 10.0,
+            latency_p95_ms: 45.0,
+            latency_p99_ms: 90.0,
+            latency_avg_ms: 15.0,
         };
         let json = serde_json::to_value(&ev).unwrap();
-        assert!(json.get("commitment").is_none());
-        assert!(json.get("estimated_cost").is_none());
+        assert_eq!(json["type"], "request_aggregate");
+        assert_eq!(json["count"], 5000);
+    }
+
+    #[test]
+    fn aggregator_drain_produces_correct_percentiles() {
+        let agg = Aggregator::new();
+        // 100 samples: 1.0, 2.0, ..., 100.0
+        for i in 1..=100 {
+            agg.record("getSlot", "helius", "ok", i as f64);
+        }
+        let events = agg.drain();
+        assert_eq!(events.len(), 1);
+        if let TelemetryEvent::RequestAggregate {
+            count,
+            latency_p50_ms,
+            latency_p95_ms,
+            latency_p99_ms,
+            latency_avg_ms,
+            ..
+        } = &events[0]
+        {
+            assert_eq!(*count, 100);
+            assert_eq!(*latency_p50_ms, 50.0);
+            assert_eq!(*latency_p95_ms, 95.0);
+            assert_eq!(*latency_p99_ms, 99.0);
+            // avg of 1..=100 = 50.5
+            assert!((latency_avg_ms - 50.5).abs() < 0.001);
+        } else {
+            panic!("expected RequestAggregate");
+        }
+    }
+
+    #[test]
+    fn aggregator_drain_resets_window() {
+        let agg = Aggregator::new();
+        agg.record("getSlot", "helius", "ok", 10.0);
+        let first = agg.drain();
+        assert_eq!(first.len(), 1);
+        // second drain with no new data should be empty
+        let second = agg.drain();
+        assert!(second.is_empty());
+    }
+
+    #[test]
+    fn aggregator_buckets_by_key() {
+        let agg = Aggregator::new();
+        agg.record("getSlot", "helius", "ok", 10.0);
+        agg.record("getSlot", "quicknode", "ok", 20.0);
+        agg.record("getBalance", "helius", "ok", 5.0);
+        agg.record("getSlot", "helius", "error", 100.0);
+        let events = agg.drain();
+        assert_eq!(events.len(), 4);
     }
 }

--- a/rpc-plane-core/src/telemetry.rs
+++ b/rpc-plane-core/src/telemetry.rs
@@ -298,9 +298,11 @@ mod tests {
         Mutex,
     };
 
+    type RequestLog = Arc<Mutex<Vec<(String, String, String, f64)>>>;
+
     struct RecordingReporter {
         events: Arc<Mutex<Vec<TelemetryEvent>>>,
-        requests: Arc<Mutex<Vec<(String, String, String, f64)>>>,
+        requests: RequestLog,
         flush_count: Arc<AtomicUsize>,
     }
 
@@ -308,7 +310,7 @@ mod tests {
         fn new() -> (
             Self,
             Arc<Mutex<Vec<TelemetryEvent>>>,
-            Arc<Mutex<Vec<(String, String, String, f64)>>>,
+            RequestLog,
             Arc<AtomicUsize>,
         ) {
             let events = Arc::new(Mutex::new(Vec::new()));

--- a/rpc-plane/src/main.rs
+++ b/rpc-plane/src/main.rs
@@ -134,7 +134,7 @@ async fn run(config_path: PathBuf) -> Result<()> {
     let health_reporter = reporter.clone();
     let health_monitor = state.monitor.clone();
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(10));
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;


### PR DESCRIPTION
## Summary

- Removes cost-aware routing and pricing config (`estimated_cost`, `PricingConfig`, `BudgetAlert`) — cost decisions belong in the dashboard layer, not the proxy
- Removes `CacheEvent` telemetry (no longer needed)
- Replaces per-request `TelemetryEvent::Request` with `TelemetryEvent::RequestAggregate`: one event per `(method, provider, status)` bucket per flush window, containing count and p50/p95/p99/avg latency percentiles
- `HealthMonitor` no longer holds a reporter or emits `ProviderHealth` on every probe; the 60-second health snapshot loop in main handles it instead
- Enforces `flush_interval_ms >= 10000` at config load time; default raised from 5000 → 60000
- Updates `config.example.toml` and docs

## Tests

All 68 unit tests and 14 integration tests passed (`cargo test --all`). `cargo clippy` clean.