### PR TITLE
Hot-path fixes: broadcast early-return, bounded+weighted batch metrics, upstream status passthrough

### DIFF
--- a/rpc-plane-core/src/metrics.rs
+++ b/rpc-plane-core/src/metrics.rs
@@ -147,11 +147,23 @@ impl Metrics {
         }))
     }
 
-    pub fn record_request(&self, method: &str, provider: &str, status: &str, latency_ms: f64) {
+    /// Record one forwarded request. `count` is the number of JSON-RPC calls it
+    /// represents — 1 for a single request, the element count for a batch — so a
+    /// 1000-call batch increments the counter by 1000 (provider-billed volume),
+    /// while the latency histogram still gets a single observation for the one
+    /// round trip.
+    pub fn record_request(
+        &self,
+        method: &str,
+        provider: &str,
+        status: &str,
+        latency_ms: f64,
+        count: u64,
+    ) {
         self.0
             .requests
             .with_label_values(&[method, provider, status])
-            .inc();
+            .inc_by(count as f64);
         if status == "ok" {
             self.0
                 .duration
@@ -217,9 +229,9 @@ mod tests {
     #[test]
     fn counter_increments_correctly() {
         let m = Metrics::new();
-        m.record_request("getSlot", "helius", "ok", 42.0);
-        m.record_request("getSlot", "helius", "ok", 58.0);
-        m.record_request("getSlot", "triton", "error", 0.0);
+        m.record_request("getSlot", "helius", "ok", 42.0, 1);
+        m.record_request("getSlot", "helius", "ok", 58.0, 1);
+        m.record_request("getSlot", "triton", "error", 0.0, 1);
 
         let text = m.render();
         assert!(text.contains(
@@ -231,9 +243,23 @@ mod tests {
     }
 
     #[test]
+    fn batch_count_weights_the_counter() {
+        let m = Metrics::new();
+        // One batch of 1000 getTransaction calls = one round trip, 1000 calls.
+        m.record_request("getTransaction", "helius", "ok", 42.0, 1000);
+
+        let text = m.render();
+        assert!(text.contains(
+            "rpc_plane_requests_total{method=\"getTransaction\",provider=\"helius\",status=\"ok\"} 1000"
+        ));
+        // Single latency observation despite the 1000-call weight.
+        assert!(text.contains("rpc_plane_request_duration_seconds_count{method=\"getTransaction\",provider=\"helius\"} 1"));
+    }
+
+    #[test]
     fn histogram_emits_buckets_and_sum() {
         let m = Metrics::new();
-        m.record_request("getSlot", "helius", "ok", 42.0);
+        m.record_request("getSlot", "helius", "ok", 42.0, 1);
 
         let text = m.render();
         // Prometheus histogram emits _bucket, _sum, _count lines.
@@ -245,7 +271,7 @@ mod tests {
     #[test]
     fn duration_not_observed_for_errors() {
         let m = Metrics::new();
-        m.record_request("getSlot", "helius", "error", 100.0);
+        m.record_request("getSlot", "helius", "error", 100.0, 1);
 
         let text = m.render();
         // No duration lines should appear when no successful requests recorded.

--- a/rpc-plane-core/src/proxy.rs
+++ b/rpc-plane-core/src/proxy.rs
@@ -169,7 +169,9 @@ async fn handle_metrics(State(state): State<ProxyState>) -> impl IntoResponse {
 
 async fn handle_rpc(State(state): State<ProxyState>, headers: HeaderMap, body: Bytes) -> Response {
     let request_id = Uuid::new_v4();
-    let method = extract_method(&body).unwrap_or_else(|| "unknown".to_string());
+    // `call_count` is the number of JSON-RPC calls (batch size) — used to weight
+    // metrics/telemetry so a 1000-call batch is billed as 1000, not 1.
+    let (method, call_count) = extract_method(&body).unwrap_or_else(|| ("unknown".to_string(), 1));
 
     let config = state.current_config();
     let snapshots = state.monitor.snapshots();
@@ -181,30 +183,34 @@ async fn handle_rpc(State(state): State<ProxyState>, headers: HeaderMap, body: B
         config.routing.broadcast_writes,
     );
 
+    let ctx = RequestCtx {
+        method: &method,
+        headers: &headers,
+        body: &body,
+        request_id,
+        count: call_count,
+    };
+
     if decision.broadcast {
-        broadcast(
-            &state,
-            &config,
-            &decision.providers,
-            &method,
-            &headers,
-            &body,
-            request_id,
-        )
-        .await
+        broadcast(&state, &config, &decision.providers, ctx).await
     } else {
-        sequential(
-            &state,
-            &config,
-            &decision.providers,
-            &method,
-            &headers,
-            &body,
-            request_id,
-        )
-        .await
+        sequential(&state, &config, &decision.providers, ctx).await
     }
 }
+
+/// Per-request routing context shared by the sequential and broadcast paths.
+/// Bundled so the hot-path fns keep a small, stable signature as fields grow.
+struct RequestCtx<'a> {
+    method: &'a str,
+    headers: &'a HeaderMap,
+    body: &'a Bytes,
+    request_id: Uuid,
+    /// JSON-RPC call count (batch size) — weights metrics/telemetry.
+    count: u64,
+}
+
+/// Result of one provider forward: (provider name, Ok(status, body) | Err(msg), latency_ms).
+type ForwardOutcome = (Arc<str>, Result<(u16, Bytes), String>, f64);
 
 // ── Sequential (reads + failover) ────────────────────────────────────────────
 
@@ -212,11 +218,15 @@ async fn sequential(
     state: &ProxyState,
     config: &Config,
     providers: &[Arc<str>],
-    method: &str,
-    headers: &HeaderMap,
-    body: &Bytes,
-    request_id: Uuid,
+    ctx: RequestCtx<'_>,
 ) -> Response {
+    let RequestCtx {
+        method,
+        headers,
+        body,
+        request_id,
+        count,
+    } = ctx;
     let max_attempts = (config.routing.max_retries + 1).min(providers.len());
     let mut prev_failed: Option<(Arc<str>, &'static str)> = None; // (name, reason)
 
@@ -248,7 +258,36 @@ async fn sequential(
         let latency_ms = t0.elapsed().as_secs_f64() * 1000.0;
 
         match result {
-            Ok(bytes) => {
+            Ok((status, bytes)) => {
+                // Non-2xx that wasn't retryable (retryable HTTP already became an
+                // Err above): a permanent provider error such as a revoked-key 401.
+                // Record it as an error so health scoring reflects real traffic, and
+                // pass the status through to the client instead of replying 200.
+                // Do not fail over — it is non-retryable by construction.
+                if !(200..300).contains(&status) {
+                    warn!(
+                        request_id = %request_id,
+                        provider = %name,
+                        method,
+                        attempt,
+                        status,
+                        "upstream non-2xx, passing status through"
+                    );
+                    state
+                        .metrics
+                        .record_request(method, name, "error", latency_ms, count);
+                    state
+                        .reporter
+                        .record_request(method, name, "error", latency_ms, count);
+                    state.monitor.record(name, false, latency_ms);
+                    return (
+                        StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
+                        [("content-type", "application/json")],
+                        bytes,
+                    )
+                        .into_response();
+                }
+
                 if let Some(code) = extract_rpc_error_code(&bytes) {
                     if is_retryable_rpc_code(code) && attempt + 1 < max_attempts {
                         warn!(
@@ -261,10 +300,10 @@ async fn sequential(
                         );
                         state
                             .metrics
-                            .record_request(method, name, "error", latency_ms);
+                            .record_request(method, name, "error", latency_ms, count);
                         state
                             .reporter
-                            .record_request(method, name, "error", latency_ms);
+                            .record_request(method, name, "error", latency_ms, count);
                         state.monitor.record(name, false, latency_ms);
                         prev_failed = Some((name.clone(), "retryable_rpc_error"));
                         continue;
@@ -278,10 +317,12 @@ async fn sequential(
                     latency_ms = format!("{latency_ms:.1}"),
                     "request ok"
                 );
-                state.metrics.record_request(method, name, "ok", latency_ms);
+                state
+                    .metrics
+                    .record_request(method, name, "ok", latency_ms, count);
                 state
                     .reporter
-                    .record_request(method, name, "ok", latency_ms);
+                    .record_request(method, name, "ok", latency_ms, count);
                 state.monitor.record(name, true, latency_ms);
                 return (
                     StatusCode::OK,
@@ -301,10 +342,10 @@ async fn sequential(
                 );
                 state
                     .metrics
-                    .record_request(method, name, "error", latency_ms);
+                    .record_request(method, name, "error", latency_ms, count);
                 state
                     .reporter
-                    .record_request(method, name, "error", latency_ms);
+                    .record_request(method, name, "error", latency_ms, count);
                 state.monitor.record(name, false, latency_ms);
                 prev_failed = Some((name.clone(), "provider_error"));
             }
@@ -321,11 +362,15 @@ async fn broadcast(
     state: &ProxyState,
     config: &Config,
     providers: &[Arc<str>],
-    method: &str,
-    headers: &HeaderMap,
-    body: &Bytes,
-    request_id: Uuid,
+    ctx: RequestCtx<'_>,
 ) -> Response {
+    let RequestCtx {
+        method,
+        headers,
+        body,
+        request_id,
+        count,
+    } = ctx;
     if providers.is_empty() {
         return json_error_response(
             StatusCode::SERVICE_UNAVAILABLE,
@@ -334,7 +379,7 @@ async fn broadcast(
         );
     }
 
-    let mut set: JoinSet<(Arc<str>, Result<Bytes, String>, f64)> = JoinSet::new();
+    let mut set: JoinSet<ForwardOutcome> = JoinSet::new();
 
     for name in providers {
         let Some(provider) = config
@@ -360,19 +405,16 @@ async fn broadcast(
         });
     }
 
-    let mut first_success: Option<Bytes> = None;
-
+    // Return on the FIRST 2xx success rather than draining the whole JoinSet —
+    // otherwise client latency tracks the slowest provider, defeating the entire
+    // point of broadcast/ParallelRace. Stragglers are handed to a detached task
+    // (below) so every provider's outcome still feeds metrics and health scoring.
     while let Some(res) = set.join_next().await {
         match res {
-            Ok((name, Ok(bytes), latency_ms)) => {
-                state
-                    .metrics
-                    .record_request(method, &name, "ok", latency_ms);
-                state
-                    .reporter
-                    .record_request(method, &name, "ok", latency_ms);
-                state.monitor.record(&name, true, latency_ms);
-                if first_success.is_none() {
+            Ok((name, Ok((status, bytes)), latency_ms)) => {
+                let success = (200..300).contains(&status);
+                record_broadcast_outcome(state, method, &name, success, latency_ms, count);
+                if success {
                     info!(
                         request_id = %request_id,
                         provider = %name,
@@ -380,18 +422,19 @@ async fn broadcast(
                         latency_ms = format!("{latency_ms:.1}"),
                         "broadcast first success"
                     );
-                    first_success = Some(bytes);
+                    spawn_straggler_drain(state, method, request_id, count, set);
+                    return (
+                        StatusCode::OK,
+                        [("content-type", "application/json")],
+                        bytes,
+                    )
+                        .into_response();
                 }
+                warn!(request_id = %request_id, provider = %name, method, status, "broadcast provider non-2xx");
             }
             Ok((name, Err(e), latency_ms)) => {
                 warn!(request_id = %request_id, provider = %name, method, error = %e, "broadcast provider failed");
-                state
-                    .metrics
-                    .record_request(method, &name, "error", latency_ms);
-                state
-                    .reporter
-                    .record_request(method, &name, "error", latency_ms);
-                state.monitor.record(&name, false, latency_ms);
+                record_broadcast_outcome(state, method, &name, false, latency_ms, count);
             }
             Err(e) => {
                 warn!(request_id = %request_id, error = %e, "broadcast task panicked");
@@ -399,18 +442,67 @@ async fn broadcast(
         }
     }
 
-    match first_success {
-        Some(bytes) => (
-            StatusCode::OK,
-            [("content-type", "application/json")],
-            bytes,
-        )
-            .into_response(),
-        None => {
-            error!(%request_id, method, "all broadcast providers failed");
-            json_error_response(StatusCode::BAD_GATEWAY, -32603, "all providers failed")
+    // Reached only when no provider produced a 2xx — every outcome was already
+    // recorded synchronously above.
+    error!(%request_id, method, "all broadcast providers failed");
+    json_error_response(StatusCode::BAD_GATEWAY, -32603, "all providers failed")
+}
+
+/// Record one broadcast provider outcome across metrics, telemetry, and health.
+fn record_broadcast_outcome(
+    state: &ProxyState,
+    method: &str,
+    name: &str,
+    success: bool,
+    latency_ms: f64,
+    count: u64,
+) {
+    let status = if success { "ok" } else { "error" };
+    state
+        .metrics
+        .record_request(method, name, status, latency_ms, count);
+    state
+        .reporter
+        .record_request(method, name, status, latency_ms, count);
+    state.monitor.record(name, success, latency_ms);
+}
+
+/// Drain the remaining in-flight broadcast tasks in the background after the
+/// client has already been answered, so late providers still feed metrics and
+/// health. Clones only the cheap Arc-backed handles off `ProxyState`; the
+/// JoinSet is moved in and owns everything it needs ('static).
+fn spawn_straggler_drain(
+    state: &ProxyState,
+    method: &str,
+    request_id: Uuid,
+    count: u64,
+    mut set: JoinSet<ForwardOutcome>,
+) {
+    let metrics = state.metrics.clone();
+    let reporter = state.reporter.clone();
+    let monitor = state.monitor.clone();
+    let method = method.to_string();
+    tokio::spawn(async move {
+        while let Some(res) = set.join_next().await {
+            let (name, success, latency_ms) = match res {
+                Ok((name, Ok((status, _)), latency_ms)) => {
+                    (name, (200..300).contains(&status), latency_ms)
+                }
+                Ok((name, Err(e), latency_ms)) => {
+                    warn!(request_id = %request_id, provider = %name, error = %e, "broadcast straggler failed");
+                    (name, false, latency_ms)
+                }
+                Err(e) => {
+                    warn!(request_id = %request_id, error = %e, "broadcast straggler task panicked");
+                    continue;
+                }
+            };
+            let status = if success { "ok" } else { "error" };
+            metrics.record_request(&method, &name, status, latency_ms, count);
+            reporter.record_request(&method, &name, status, latency_ms, count);
+            monitor.record(&name, success, latency_ms);
         }
-    }
+    });
 }
 
 // ── HTTP forwarding ───────────────────────────────────────────────────────────
@@ -420,7 +512,7 @@ async fn forward(
     provider: &ProviderConfig,
     incoming_headers: &HeaderMap,
     body: &Bytes,
-) -> anyhow::Result<Bytes> {
+) -> anyhow::Result<(u16, Bytes)> {
     let mut builder = client
         .post(&provider.url)
         .header("content-type", "application/json")
@@ -439,10 +531,14 @@ async fn forward(
     let resp = builder.body(body.clone()).send().await?;
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await?;
+    // Retryable statuses (429/5xx) become an Err so the caller fails over to the
+    // next provider. Every other status — including non-retryable 4xx like a
+    // revoked-key 401 — is returned with its code so the caller can pass it
+    // through to the client and score it correctly, instead of masking it as 200.
     if is_retryable_http(status) {
         anyhow::bail!("provider returned HTTP {status}");
     }
-    Ok(bytes)
+    Ok((status, bytes))
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -454,20 +550,56 @@ struct MethodField<'a> {
     method: Option<&'a str>,
 }
 
-pub fn extract_method(body: &[u8]) -> Option<String> {
+/// Max distinct method names rendered into a batch label before the remainder is
+/// collapsed into a `+N` suffix.
+const MAX_BATCH_LABEL_METHODS: usize = 5;
+/// Hard ceiling on the rendered method label (a Prometheus label value and a
+/// telemetry-aggregator map key). Defensive against pathologically long names.
+const MAX_METHOD_LABEL_LEN: usize = 128;
+
+/// Returns the (bounded method label, JSON-RPC call count) for a request body.
+/// A single request is one call; a batch's call count is the number of
+/// method-bearing elements. The label is bounded so a large/varied batch can't
+/// mint a giant, unbounded-cardinality metrics label / aggregator key (the raw
+/// `join(",")` let a 1000-element batch produce a ~15 KB never-evicted key); the
+/// count weights metrics/telemetry so that batch is billed as its true volume.
+pub fn extract_method(body: &[u8]) -> Option<(String, u64)> {
     let first = body.iter().find(|&&b| !b.is_ascii_whitespace())?;
     if *first == b'{' {
         // Single request: parse only the method field, skip everything else.
         let req: MethodField<'_> = serde_json::from_slice(body).ok()?;
-        return req.method.map(|m| m.to_owned());
+        return req.method.map(|m| (m.to_owned(), 1));
     }
-    // Batch request.
+    // Batch request. Dedup method names (first-seen order), render up to
+    // MAX_BATCH_LABEL_METHODS distinct names, collapse the rest into `+N`. A
+    // homogeneous batch of 1000 `getTransaction` therefore labels as
+    // `getTransaction` — identical to the single request, so dashboards group
+    // them — while `count` carries the real 1000-call volume.
     let arr: Vec<MethodField<'_>> = serde_json::from_slice(body).ok()?;
-    let methods: Vec<&str> = arr.iter().filter_map(|r| r.method).collect();
-    if methods.is_empty() {
+    let mut uniques: Vec<&str> = Vec::new();
+    let mut calls: u64 = 0;
+    for m in arr.iter().filter_map(|r| r.method) {
+        calls += 1;
+        if !uniques.contains(&m) {
+            uniques.push(m);
+        }
+    }
+    if uniques.is_empty() {
         return None;
     }
-    Some(methods.join(","))
+    let shown = uniques.len().min(MAX_BATCH_LABEL_METHODS);
+    let mut label = uniques[..shown].join(",");
+    if uniques.len() > shown {
+        label.push_str(&format!("+{}", uniques.len() - shown));
+    }
+    if label.len() > MAX_METHOD_LABEL_LEN {
+        let mut end = MAX_METHOD_LABEL_LEN;
+        while !label.is_char_boundary(end) {
+            end -= 1;
+        }
+        label.truncate(end);
+    }
+    Some((label, calls))
 }
 
 fn json_error_response(status: StatusCode, code: i64, message: &str) -> Response {
@@ -490,7 +622,7 @@ mod tests {
     fn extract_method_works() {
         assert_eq!(
             extract_method(br#"{"jsonrpc":"2.0","id":1,"method":"getSlot"}"#),
-            Some("getSlot".to_string())
+            Some(("getSlot".to_string(), 1))
         );
     }
 
@@ -505,12 +637,55 @@ mod tests {
     }
 
     #[test]
-    fn extract_method_batch_array_joins_methods() {
+    fn extract_method_batch_distinct_methods_kept() {
         let batch = br#"[{"jsonrpc":"2.0","id":1,"method":"getSlot"},{"jsonrpc":"2.0","id":2,"method":"getBalance"}]"#;
         assert_eq!(
             extract_method(batch),
-            Some("getSlot,getBalance".to_string())
+            Some(("getSlot,getBalance".to_string(), 2))
         );
+    }
+
+    #[test]
+    fn extract_method_homogeneous_batch_collapses_to_single_label() {
+        // 1000× getTransaction: label collapses to the bare method (matching a
+        // single request so dashboards group them), count carries the volume.
+        let one = r#"{"jsonrpc":"2.0","id":1,"method":"getTransaction"}"#;
+        let batch = format!("[{}]", vec![one; 1000].join(","));
+        let (label, count) = extract_method(batch.as_bytes()).unwrap();
+        assert_eq!(label, "getTransaction");
+        assert_eq!(count, 1000);
+        // The label is bounded regardless of batch size.
+        assert!(label.len() <= MAX_METHOD_LABEL_LEN);
+    }
+
+    #[test]
+    fn extract_method_many_distinct_methods_capped_with_suffix() {
+        // 8 distinct methods → first 5 rendered, remainder collapsed to `+3`.
+        let methods = [
+            "getSlot",
+            "getBalance",
+            "getAccountInfo",
+            "getBlock",
+            "getTransaction",
+            "getSignatureStatuses",
+            "getEpochInfo",
+            "getVersion",
+        ];
+        let body = format!(
+            "[{}]",
+            methods
+                .iter()
+                .enumerate()
+                .map(|(i, m)| format!(r#"{{"jsonrpc":"2.0","id":{i},"method":"{m}"}}"#))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let (label, count) = extract_method(body.as_bytes()).unwrap();
+        assert_eq!(
+            label,
+            "getSlot,getBalance,getAccountInfo,getBlock,getTransaction+3"
+        );
+        assert_eq!(count, 8);
     }
 
     #[test]

--- a/rpc-plane-core/src/telemetry.rs
+++ b/rpc-plane-core/src/telemetry.rs
@@ -55,9 +55,20 @@ pub trait Reporter: Send + Sync {
     /// Emit a raw event (Failover, Divergence, ProviderHealth). Must never block.
     fn emit(&self, event: TelemetryEvent);
 
-    /// Record a single request outcome into the aggregate accumulator.
-    /// Default implementation is a no-op (used by NoopReporter).
-    fn record_request(&self, _method: &str, _provider: &str, _status: &str, _latency_ms: f64) {}
+    /// Record a single request outcome into the aggregate accumulator. `count`
+    /// is the number of JSON-RPC calls the request represents (1 for a single
+    /// request, the batch element count otherwise) so aggregate `count` reflects
+    /// provider-billed call volume, while latency stats use the one round-trip
+    /// sample. Default implementation is a no-op (used by NoopReporter).
+    fn record_request(
+        &self,
+        _method: &str,
+        _provider: &str,
+        _status: &str,
+        _latency_ms: f64,
+        _count: u64,
+    ) {
+    }
 
     /// Signal the reporter to flush any buffered events. Fire-and-forget.
     fn flush(&self);
@@ -83,8 +94,18 @@ struct Aggregator {
 
 struct AggState {
     // key: (method, provider, status)
-    buckets: HashMap<(String, String, String), Vec<f64>>,
+    buckets: HashMap<(String, String, String), Bucket>,
     window_start_ms: u64,
+}
+
+/// One aggregation bucket. `count` is provider-billed call volume (batch-weighted
+/// and may exceed `latencies.len()`); `latencies` holds one sample per round trip,
+/// so a 1000-call batch contributes 1000 to `count` but a single latency sample —
+/// keeping percentiles meaningful and the Vec bounded.
+#[derive(Default)]
+struct Bucket {
+    count: u64,
+    latencies: Vec<f64>,
 }
 
 impl Aggregator {
@@ -97,12 +118,14 @@ impl Aggregator {
         }
     }
 
-    fn record(&self, method: &str, provider: &str, status: &str, latency_ms: f64) {
+    fn record(&self, method: &str, provider: &str, status: &str, latency_ms: f64, count: u64) {
         let mut s = self.state.lock().unwrap();
-        s.buckets
+        let bucket = s
+            .buckets
             .entry((method.to_string(), provider.to_string(), status.to_string()))
-            .or_default()
-            .push(latency_ms);
+            .or_default();
+        bucket.count += count;
+        bucket.latencies.push(latency_ms);
     }
 
     /// Drain all buckets into `RequestAggregate` events and reset the window.
@@ -114,11 +137,16 @@ impl Aggregator {
         let events = s
             .buckets
             .drain()
-            .filter(|(_, v)| !v.is_empty())
-            .map(|((method, provider, status), mut latencies)| {
+            .filter(|(_, b)| !b.latencies.is_empty())
+            .map(|((method, provider, status), bucket)| {
+                let Bucket {
+                    count,
+                    mut latencies,
+                } = bucket;
                 let sum: f64 = latencies.iter().sum();
-                let count = latencies.len() as u64;
-                let latency_avg_ms = sum / count as f64;
+                // Average over latency samples (round trips), not the call-weighted
+                // `count`, so a batch's single sample isn't divided by its call volume.
+                let latency_avg_ms = sum / latencies.len() as f64;
                 latencies.sort_unstable_by(|a, b| a.total_cmp(b));
                 TelemetryEvent::RequestAggregate {
                     window_start_ms: window_start,
@@ -196,8 +224,16 @@ impl Reporter for RemoteReporter {
         let _ = self.tx.try_send(event);
     }
 
-    fn record_request(&self, method: &str, provider: &str, status: &str, latency_ms: f64) {
-        self.aggregator.record(method, provider, status, latency_ms);
+    fn record_request(
+        &self,
+        method: &str,
+        provider: &str,
+        status: &str,
+        latency_ms: f64,
+        count: u64,
+    ) {
+        self.aggregator
+            .record(method, provider, status, latency_ms, count);
     }
 
     fn flush(&self) {
@@ -298,7 +334,7 @@ mod tests {
         Mutex,
     };
 
-    type RequestLog = Arc<Mutex<Vec<(String, String, String, f64)>>>;
+    type RequestLog = Arc<Mutex<Vec<(String, String, String, f64, u64)>>>;
 
     struct RecordingReporter {
         events: Arc<Mutex<Vec<TelemetryEvent>>>,
@@ -329,12 +365,20 @@ mod tests {
         fn emit(&self, event: TelemetryEvent) {
             self.events.lock().unwrap().push(event);
         }
-        fn record_request(&self, method: &str, provider: &str, status: &str, latency_ms: f64) {
+        fn record_request(
+            &self,
+            method: &str,
+            provider: &str,
+            status: &str,
+            latency_ms: f64,
+            count: u64,
+        ) {
             self.requests.lock().unwrap().push((
                 method.to_string(),
                 provider.to_string(),
                 status.to_string(),
                 latency_ms,
+                count,
             ));
         }
         fn flush(&self) {
@@ -350,7 +394,7 @@ mod tests {
             to_provider: "b".into(),
             reason: "test".into(),
         });
-        r.record_request("getSlot", "helius", "ok", 1.0);
+        r.record_request("getSlot", "helius", "ok", 1.0, 1);
         r.flush();
         // no panic = pass
     }
@@ -363,7 +407,7 @@ mod tests {
             to_provider: "b".into(),
             reason: "test".into(),
         });
-        reporter.record_request("getSlot", "helius", "ok", 12.5);
+        reporter.record_request("getSlot", "helius", "ok", 12.5, 1);
         reporter.flush();
 
         assert_eq!(events.lock().unwrap().len(), 1);
@@ -407,7 +451,7 @@ mod tests {
         let agg = Aggregator::new();
         // 100 samples: 1.0, 2.0, ..., 100.0
         for i in 1..=100 {
-            agg.record("getSlot", "helius", "ok", i as f64);
+            agg.record("getSlot", "helius", "ok", i as f64, 1);
         }
         let events = agg.drain();
         assert_eq!(events.len(), 1);
@@ -432,9 +476,33 @@ mod tests {
     }
 
     #[test]
+    fn batch_weighted_count_keeps_single_latency_sample() {
+        let agg = Aggregator::new();
+        // One batch of 1000 getTransaction calls: 1000 to count, one 200ms sample.
+        agg.record("getTransaction", "helius", "ok", 200.0, 1000);
+        let events = agg.drain();
+        assert_eq!(events.len(), 1);
+        if let TelemetryEvent::RequestAggregate {
+            count,
+            latency_avg_ms,
+            latency_p50_ms,
+            ..
+        } = &events[0]
+        {
+            // Call volume is weighted by batch size...
+            assert_eq!(*count, 1000);
+            // ...but latency is the one round-trip sample, not 200/1000.
+            assert_eq!(*latency_avg_ms, 200.0);
+            assert_eq!(*latency_p50_ms, 200.0);
+        } else {
+            panic!("expected RequestAggregate");
+        }
+    }
+
+    #[test]
     fn aggregator_drain_resets_window() {
         let agg = Aggregator::new();
-        agg.record("getSlot", "helius", "ok", 10.0);
+        agg.record("getSlot", "helius", "ok", 10.0, 1);
         let first = agg.drain();
         assert_eq!(first.len(), 1);
         // second drain with no new data should be empty
@@ -445,10 +513,10 @@ mod tests {
     #[test]
     fn aggregator_buckets_by_key() {
         let agg = Aggregator::new();
-        agg.record("getSlot", "helius", "ok", 10.0);
-        agg.record("getSlot", "quicknode", "ok", 20.0);
-        agg.record("getBalance", "helius", "ok", 5.0);
-        agg.record("getSlot", "helius", "error", 100.0);
+        agg.record("getSlot", "helius", "ok", 10.0, 1);
+        agg.record("getSlot", "quicknode", "ok", 20.0, 1);
+        agg.record("getBalance", "helius", "ok", 5.0, 1);
+        agg.record("getSlot", "helius", "error", 100.0, 1);
         let events = agg.drain();
         assert_eq!(events.len(), 4);
     }

--- a/rpc-plane-core/tests/integration.rs
+++ b/rpc-plane-core/tests/integration.rs
@@ -19,6 +19,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
+use std::time::Duration;
 use tower::ServiceExt;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -41,6 +42,20 @@ async fn start_mock(router: Router) -> (String, tokio::task::AbortHandle) {
         axum::serve(listener, router).await.unwrap();
     });
     (format!("http://{addr}"), handle.abort_handle())
+}
+
+/// Start a mock that sleeps `delay` before answering every POST with `slot`.
+/// Used to model a degraded-but-eventually-successful provider so broadcast /
+/// ParallelRace early-return can be observed against the wall clock.
+async fn start_slow_mock(slot: u64, delay: Duration) -> (String, tokio::task::AbortHandle) {
+    let router = Router::new().route(
+        "/",
+        post(move || async move {
+            tokio::time::sleep(delay).await;
+            slot_response(slot)
+        }),
+    );
+    start_mock(router).await
 }
 
 /// Build a test Config that disables background health/slot probes (huge intervals)
@@ -610,5 +625,114 @@ async fn handler_panic_returns_500_not_connection_drop() {
         resp.status(),
         StatusCode::INTERNAL_SERVER_ERROR,
         "panic should yield 500, not a connection drop"
+    );
+}
+
+// ── Contract tests ──────────────────────────────────────────────────────────────
+//
+// These pin documented routing/forwarding behaviour. They began life #[ignore]d
+// and failing (documenting bugs the code didn't yet honour); the Milestone 1
+// fixes — broadcast early-return and upstream non-2xx passthrough — landed, so
+// they now run as regression gates.
+
+/// CONTRACT: broadcast must respond on the FIRST provider success, not after the
+/// slowest provider finishes. With
+/// `broadcast_writes`, `sendTransaction` fans out to every provider; a fast
+/// provider and a degraded one (5 s) race, and the client must see the fast
+/// success well under 1 s. The slow provider's outcome is still recorded by the
+/// detached straggler drain, but off the client's critical path.
+#[tokio::test]
+async fn broadcast_returns_on_first_success_before_slow_provider() {
+    let (url_fast, _abort_fast) =
+        start_mock(Router::new().route("/", post(|| async { slot_response(111) }))).await;
+    let (url_slow, _abort_slow) = start_slow_mock(222, Duration::from_secs(5)).await;
+
+    let mut cfg = test_config(
+        &[("fast", &url_fast), ("slow", &url_slow)],
+        RoutingStrategy::BestScore,
+        0,
+        5,
+    );
+    cfg.routing.broadcast_writes = true;
+    let state = ProxyState::new(cfg);
+    let router = build_router(state);
+
+    let started = std::time::Instant::now();
+    let outcome =
+        tokio::time::timeout(Duration::from_secs(1), proxy_request(router, SEND_TX)).await;
+    let elapsed = started.elapsed();
+
+    let (status, body) =
+        outcome.expect("broadcast did not respond within 1s — it waited for the slow provider");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["result"].as_u64(),
+        Some(111),
+        "should return the fast provider's response"
+    );
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "broadcast took {elapsed:?}; expected first-success well under 1s"
+    );
+}
+
+/// CONTRACT: ParallelRace is documented to return the fastest success. It routes
+/// reads through the broadcast path, so a read (`getSlot`) raced across a fast and
+/// a 5 s-degraded provider must return the fast result well under 1 s — the same
+/// early-return property, on the read path.
+#[tokio::test]
+async fn parallel_race_returns_first_success_not_slowest() {
+    let (url_fast, _abort_fast) =
+        start_mock(Router::new().route("/", post(|| async { slot_response(111) }))).await;
+    let (url_slow, _abort_slow) = start_slow_mock(222, Duration::from_secs(5)).await;
+
+    let cfg = test_config(
+        &[("fast", &url_fast), ("slow", &url_slow)],
+        RoutingStrategy::ParallelRace,
+        0,
+        5,
+    );
+    let state = ProxyState::new(cfg);
+    let router = build_router(state);
+
+    let started = std::time::Instant::now();
+    let outcome =
+        tokio::time::timeout(Duration::from_secs(1), proxy_request(router, GET_SLOT)).await;
+    let elapsed = started.elapsed();
+
+    let (status, body) = outcome
+        .expect("ParallelRace did not respond within 1s — it waited for the slowest provider");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["result"].as_u64(), Some(111));
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "ParallelRace took {elapsed:?}; expected first-success well under 1s"
+    );
+}
+
+/// CONTRACT: a non-retryable upstream 4xx (e.g. a revoked key → 401) must be
+/// surfaced to the client as that status, not masked as HTTP 200. Chosen
+/// semantics: pass the provider status code through to the client.
+///
+/// Single provider, no retry — there is nowhere to fail over, so the client must
+/// simply see the 401 (and the provider is scored as an error, not healthy).
+#[tokio::test]
+async fn upstream_4xx_status_passed_through_not_200() {
+    let mock = Router::new().route(
+        "/",
+        post(|| async { (StatusCode::UNAUTHORIZED, r#"{"error":"invalid api key"}"#) }),
+    );
+    let (url, _abort) = start_mock(mock).await;
+
+    let cfg = test_config(&[("a", &url)], RoutingStrategy::FailoverOrdered, 0, 5);
+    let state = ProxyState::new(cfg);
+    let router = build_router(state);
+
+    let (status, _body) = proxy_request(router, GET_SLOT).await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "upstream 401 must pass through, not be masked as 200"
     );
 }


### PR DESCRIPTION
## What

Three correctness fixes on the proxy hot path, with integration tests that pin each behavior.

### Broadcast / ParallelRace early-return
`broadcast()` drained the entire `JoinSet` before replying, so client latency tracked the **slowest** provider — inverting the value of `parallel_race` and `broadcast_writes`. It now returns on the first 2xx success and drains the remaining providers in a detached task, so every provider's health/metrics are still recorded but off the client's critical path.

### Bounded + call-weighted batch metrics
A batch's method label was `methods.join(",")` — a 1000-element batch produced a ~15 KB, never-evicted Prometheus label value / aggregator key. Labels are now deduplicated and capped (≤5 distinct + `+N`, 128-char ceiling); a homogeneous batch collapses to the bare method name and groups with single calls.

Counters and telemetry aggregates are now weighted by batch **call count**: a 1000-call batch is recorded as 1000 calls (one latency sample per round trip), so request volume and cost-relevant totals are accurate. `rpc_plane_requests_total` now counts JSON-RPC calls rather than HTTP requests — see the docs update.

### Upstream status passthrough
A non-retryable upstream non-2xx (e.g. a revoked-key 401) was returned to the client as HTTP 200 and scored as healthy. It now passes the upstream status through and is recorded as an error in metrics/health. Retryable statuses (429/5xx) still fail over; non-retryable 4xx still does not retry.

## Verification
`cargo fmt --all` clean · `cargo clippy --all-targets` 0 warnings · `cargo test --all` green (72 lib + 17 integration, including the three new contract tests).