### PR TITLE
Config validation, http3/pool hot-reload, and docs-coverage CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,34 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: test
         run: cargo test --all
+
+  docs-coverage:
+    name: Docs coverage
+    runs-on: ubuntu-latest
+    # The docs live in the private rpcplane/docs repo. Checking it out needs a
+    # token with read access, exposed as the DOCS_REPO_TOKEN secret. That secret
+    # is unavailable to fork PRs (and may be unset), so this job skips cleanly
+    # rather than failing when it can't reach the docs.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Detect docs token
+        id: docs
+        env:
+          DOCS_REPO_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+        run: |
+          if [ -n "$DOCS_REPO_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::DOCS_REPO_TOKEN not set — skipping config docs-coverage check"
+          fi
+      - name: Checkout docs
+        if: steps.docs.outputs.available == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: rpcplane/docs
+          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          path: _docs
+      - name: Verify every config field is documented
+        if: steps.docs.outputs.available == 'true'
+        run: ./scripts/check-docs-coverage.sh _docs/docs/configuration.md

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,6 +3,7 @@ listen         = "127.0.0.1:9400"
 metrics_listen = "127.0.0.1:9401"
 # listen_backlog        = 4096   # OS TCP backlog; raise net.core.somaxconn too for 1000+ concurrency
 # pool_max_idle_per_host = 512   # idle outbound connections per provider; set >= peak concurrency
+# worker_threads        = 4      # Tokio worker threads; defaults to logical CPU count (restart to change)
 
 # ── Health scoring ─────────────────────────────────────────────────────────────
 [health]
@@ -33,7 +34,7 @@ max_retries      = 2               # retry on next-best provider on transient er
 name   = "helius"
 url    = "https://mainnet.helius-rpc.com/?api-key=${HELIUS_API_KEY}"
 weight = 1
-http3  = true
+http3  = true   # experimental HTTP/3 (QUIC); falls back to HTTP/2 — see docs caveat
 
 [[providers]]
 name   = "quicknode"

--- a/rpc-plane-core/src/config.rs
+++ b/rpc-plane-core/src/config.rs
@@ -20,7 +20,13 @@ impl Config {
     pub fn load(path: &Path) -> Result<Self> {
         let raw = std::fs::read_to_string(path)
             .with_context(|| format!("failed to read config: {}", path.display()))?;
-        let expanded = expand_env_vars(&raw);
+        let (expanded, unset_vars) = expand_env_vars(&raw);
+        for var in &unset_vars {
+            tracing::warn!(
+                "config references unset environment variable `${{{var}}}`; it expanded \
+                 to an empty string — any provider URL using it is now missing that value"
+            );
+        }
         let config: Config = toml::from_str(&expanded)
             .with_context(|| format!("failed to parse config: {}", path.display()))?;
         config.validate()?;
@@ -32,8 +38,14 @@ impl Config {
             !self.providers.is_empty(),
             "config must have at least one [[providers]] entry"
         );
+        let mut seen = std::collections::HashSet::new();
         for p in &self.providers {
             anyhow::ensure!(!p.url.is_empty(), "provider '{}' has an empty url", p.name);
+            anyhow::ensure!(
+                seen.insert(p.name.as_str()),
+                "duplicate provider name '{}'; provider names must be unique",
+                p.name
+            );
         }
         if let Some(r) = &self.reporting {
             anyhow::ensure!(
@@ -51,13 +63,24 @@ impl Config {
     }
 }
 
-fn expand_env_vars(input: &str) -> String {
-    // shellexpand handles both ${VAR} and $VAR, leaving unset variables as
-    // empty strings rather than erroring (same behaviour as before).
-    shellexpand::env_with_context_no_errors(input, |var| {
-        Some(std::env::var(var).unwrap_or_default())
+/// Expand `${VAR}` / `$VAR` references against the process environment.
+///
+/// Unset variables expand to an empty string (preserving prior behaviour) but
+/// their names are collected and returned, sorted and de-duplicated, so callers
+/// can warn about likely typos that would otherwise silently produce a broken
+/// URL (e.g. `${HELIUS_API_KY}` → `...?api-key=`). Configs that hardcode the
+/// full URL+token reference no variables and so report nothing.
+pub fn expand_env_vars(input: &str) -> (String, Vec<String>) {
+    use std::cell::RefCell;
+    let unset: RefCell<std::collections::BTreeSet<String>> = RefCell::new(Default::default());
+    let expanded = shellexpand::env_with_context_no_errors(input, |var| {
+        Some(std::env::var(var).unwrap_or_else(|_| {
+            unset.borrow_mut().insert(var.to_string());
+            String::new()
+        }))
     })
-    .into_owned()
+    .into_owned();
+    (expanded, unset.into_inner().into_iter().collect())
 }
 
 // ── Server ─────────────────────────────────────────────────────────────────
@@ -353,6 +376,44 @@ url = ""
 "#,
         );
         assert!(Config::load(f.path()).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_provider_names() {
+        let f = write_config(
+            r#"
+[[providers]]
+name = "helius"
+url = "http://localhost:8899"
+
+[[providers]]
+name = "helius"
+url = "http://localhost:8900"
+"#,
+        );
+        let err = Config::load(f.path()).unwrap_err().to_string();
+        assert!(err.contains("duplicate provider name"), "got: {err}");
+        assert!(err.contains("helius"), "got: {err}");
+    }
+
+    #[test]
+    fn expand_env_vars_reports_unset_references() {
+        let (expanded, unset) =
+            expand_env_vars("url = \"https://rpc.example/?api-key=${RPC_PLANE_DEFINITELY_UNSET}\"");
+        assert_eq!(expanded, "url = \"https://rpc.example/?api-key=\"");
+        assert_eq!(unset, vec!["RPC_PLANE_DEFINITELY_UNSET".to_string()]);
+    }
+
+    #[test]
+    fn expand_env_vars_reports_nothing_when_hardcoded() {
+        // A fully hardcoded URL+token references no variables → no warnings.
+        let (expanded, unset) =
+            expand_env_vars("url = \"https://rpc.example/?api-key=hardcoded-token\"");
+        assert_eq!(
+            expanded,
+            "url = \"https://rpc.example/?api-key=hardcoded-token\""
+        );
+        assert!(unset.is_empty());
     }
 
     #[test]

--- a/rpc-plane/src/main.rs
+++ b/rpc-plane/src/main.rs
@@ -189,6 +189,22 @@ async fn run(config_path: PathBuf) -> Result<()> {
 }
 
 async fn check(config_path: PathBuf) -> Result<()> {
+    // Re-expand the raw file first so we can flag references to unset env vars
+    // (e.g. a typo'd `${HELIUS_API_KY}`) that silently collapse to empty and
+    // would otherwise show up only as runtime 401s.
+    if let Ok(raw) = std::fs::read_to_string(&config_path) {
+        let (_, unset_vars) = rpc_plane_core::config::expand_env_vars(&raw);
+        for var in &unset_vars {
+            println!(
+                "[WARN] environment variable `${var}` is unset — it expanded to an empty \
+                 string; any provider URL using it is missing that value"
+            );
+        }
+        if !unset_vars.is_empty() {
+            println!();
+        }
+    }
+
     let config = rpc_plane_core::config::Config::load(&config_path)?;
     println!(
         "Config OK — {} provider(s) configured\n",
@@ -361,13 +377,28 @@ async fn watch_config(
             }
         };
 
-        // Snapshot old provider map for diffing.
-        let old_providers: HashMap<String, String> = config
-            .read()
-            .providers
-            .iter()
-            .map(|p| (p.name.clone(), p.url.clone()))
-            .collect();
+        // Snapshot old config for diffing (clone out so we don't hold the lock).
+        let (old_providers, old_server) = {
+            let old = config.read();
+            let providers: HashMap<String, rpc_plane_core::config::ProviderConfig> = old
+                .providers
+                .iter()
+                .map(|p| (p.name.clone(), p.clone()))
+                .collect();
+            (providers, old.server.clone())
+        };
+
+        // pool_max_idle_per_host feeds every outbound client, so a change forces
+        // a full client rebuild — otherwise the new pool size never takes effect.
+        let pool_size_changed =
+            old_server.pool_max_idle_per_host != new_config.server.pool_max_idle_per_host;
+        if pool_size_changed {
+            info!(
+                old = old_server.pool_max_idle_per_host,
+                new = new_config.server.pool_max_idle_per_host,
+                "hot reload: pool_max_idle_per_host changed — rebuilding all provider clients"
+            );
+        }
 
         let new_providers: HashMap<String, _> = new_config
             .providers
@@ -384,43 +415,42 @@ async fn watch_config(
             }
         }
 
-        // Added providers + URL-changed providers (treat as remove then add).
+        // Added providers + providers whose client inputs changed. The reqwest
+        // client is rebuilt whenever its inputs change: the URL, the `http3`
+        // flag, or the global pool size. weight is routing-only and is picked up
+        // live when the config swaps below, so it needs no rebuild.
         for (name, new_p) in &new_providers {
-            match old_providers.get(name) {
-                Some(old_url) if old_url == &new_p.url => {
-                    // Unchanged — keep existing health state.
-                }
-                Some(_) => {
-                    clients.write().remove(name);
-                    monitor.remove_provider(name);
-                    let client = Arc::new(rpc_plane_core::proxy::build_client(
-                        new_p,
-                        new_config.server.pool_max_idle_per_host,
-                    ));
-                    clients.write().insert(name.clone(), client.clone());
-                    monitor.add_provider(client, new_p.clone());
-                    info!(provider = %name, "hot reload: provider URL updated");
-                }
-                None => {
-                    let client = Arc::new(rpc_plane_core::proxy::build_client(
-                        new_p,
-                        new_config.server.pool_max_idle_per_host,
-                    ));
-                    clients.write().insert(name.clone(), client.clone());
-                    monitor.add_provider(client, new_p.clone());
-                    info!(provider = %name, "hot reload: provider added");
-                }
+            let Some(reason) =
+                client_rebuild_reason(old_providers.get(name), new_p, pool_size_changed)
+            else {
+                continue; // client inputs unchanged — keep existing health state
+            };
+
+            // Rebuild = remove-then-add for an existing provider; plain add otherwise.
+            if old_providers.contains_key(name) {
+                clients.write().remove(name);
+                monitor.remove_provider(name);
             }
+            let client = Arc::new(rpc_plane_core::proxy::build_client(
+                new_p,
+                new_config.server.pool_max_idle_per_host,
+            ));
+            clients.write().insert(name.clone(), client.clone());
+            monitor.add_provider(client, new_p.clone());
+            info!(provider = %name, reason, "hot reload: provider client (re)built");
         }
 
-        // Warn about settings that require a restart.
+        // Warn about settings that need a restart to take effect (the runtime
+        // and listening sockets are already built).
+        if old_server.listen != new_config.server.listen
+            || old_server.metrics_listen != new_config.server.metrics_listen
+            || old_server.listen_backlog != new_config.server.listen_backlog
+            || old_server.worker_threads != new_config.server.worker_threads
         {
-            let old = config.read();
-            if old.server.listen != new_config.server.listen
-                || old.server.metrics_listen != new_config.server.metrics_listen
-            {
-                warn!("server.listen / metrics_listen changed — restart required to take effect");
-            }
+            warn!(
+                "a restart-only server setting changed (listen / metrics_listen / \
+                 listen_backlog / worker_threads) — restart required to take effect"
+            );
         }
 
         *config.write() = Arc::new(new_config);
@@ -430,6 +460,24 @@ async fn watch_config(
 
 fn mtime(path: &Path) -> Option<SystemTime> {
     std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+/// Decide whether a provider's outbound reqwest client must be rebuilt on hot
+/// reload. Returns a short human-readable reason, or `None` when none of the
+/// client's inputs (URL, `http3`, or the global pool size) changed. `weight` is
+/// deliberately excluded: it only affects routing, which reads the live config.
+fn client_rebuild_reason(
+    old: Option<&rpc_plane_core::config::ProviderConfig>,
+    new: &rpc_plane_core::config::ProviderConfig,
+    pool_size_changed: bool,
+) -> Option<&'static str> {
+    match old {
+        None => Some("added"),
+        Some(_) if pool_size_changed => Some("pool size changed"),
+        Some(o) if o.url != new.url => Some("URL updated"),
+        Some(o) if o.http3 != new.http3 => Some("http3 toggled"),
+        Some(_) => None,
+    }
 }
 
 // ── Networking helpers ────────────────────────────────────────────────────────
@@ -539,5 +587,72 @@ async fn shutdown_signal() {
     tokio::select! {
         _ = ctrl_c => info!("received Ctrl+C"),
         _ = terminate => info!("received SIGTERM"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rpc_plane_core::config::ProviderConfig;
+
+    fn provider(url: &str, http3: bool) -> ProviderConfig {
+        ProviderConfig {
+            name: "p".to_string(),
+            url: url.to_string(),
+            weight: 1,
+            http3,
+        }
+    }
+
+    #[test]
+    fn rebuild_when_provider_added() {
+        let new = provider("http://a", false);
+        assert_eq!(client_rebuild_reason(None, &new, false), Some("added"));
+    }
+
+    #[test]
+    fn no_rebuild_when_inputs_unchanged() {
+        let old = provider("http://a", false);
+        let new = provider("http://a", false);
+        assert_eq!(client_rebuild_reason(Some(&old), &new, false), None);
+    }
+
+    #[test]
+    fn rebuild_when_http3_toggled() {
+        let old = provider("http://a", false);
+        let new = provider("http://a", true);
+        assert_eq!(
+            client_rebuild_reason(Some(&old), &new, false),
+            Some("http3 toggled")
+        );
+    }
+
+    #[test]
+    fn rebuild_when_url_changed() {
+        let old = provider("http://a", false);
+        let new = provider("http://b", false);
+        assert_eq!(
+            client_rebuild_reason(Some(&old), &new, false),
+            Some("URL updated")
+        );
+    }
+
+    #[test]
+    fn rebuild_all_when_pool_size_changed() {
+        // Identical provider, but a global pool-size change forces a rebuild.
+        let old = provider("http://a", false);
+        let new = provider("http://a", false);
+        assert_eq!(
+            client_rebuild_reason(Some(&old), &new, true),
+            Some("pool size changed")
+        );
+    }
+
+    #[test]
+    fn weight_change_alone_does_not_rebuild() {
+        let old = provider("http://a", false);
+        let mut new = provider("http://a", false);
+        new.weight = 99;
+        assert_eq!(client_rebuild_reason(Some(&old), &new, false), None);
     }
 }

--- a/scripts/check-docs-coverage.sh
+++ b/scripts/check-docs-coverage.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Asserts that every serde-deserialized field in the user-facing config structs
+# (ServerConfig, HealthConfig, RoutingConfig, ProviderConfig) is mentioned in the
+# documentation. This automates the docs-sync rule: a flag that lands in
+# config.rs without a matching entry in configuration.md fails the build.
+#
+# Usage:
+#   scripts/check-docs-coverage.sh [path/to/configuration.md]
+#
+# The docs live in a separate repository, so CI checks it out and passes its
+# path. When run with no argument, the script guesses a sibling docs/ checkout.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_RS="$ROOT/rpc-plane-core/src/config.rs"
+DOCS="${1:-$ROOT/../docs/docs/configuration.md}"
+
+if [[ ! -f "$CONFIG_RS" ]]; then
+  echo "error: cannot find config source at $CONFIG_RS" >&2
+  exit 2
+fi
+if [[ ! -f "$DOCS" ]]; then
+  echo "error: cannot find configuration.md at $DOCS" >&2
+  echo "       pass its path as the first argument" >&2
+  exit 2
+fi
+
+# Extract the serde field name of every `pub` field inside the four user-facing
+# config structs. A field-level #[serde(rename = "...")] wins over the Rust name.
+# Uses only POSIX awk features so it runs under both mawk and gawk.
+fields="$(awk '
+  /^pub struct (ServerConfig|HealthConfig|RoutingConfig|ProviderConfig) \{/ { in_s=1; rename=""; next }
+  in_s && /^\}/                                                            { in_s=0; rename=""; next }
+  !in_s { next }
+  /#\[serde\(rename = "/ {
+    s=$0
+    if (match(s, /rename = "[^"]+"/)) {
+      t=substr(s, RSTART, RLENGTH); sub(/rename = "/, "", t); sub(/"$/, "", t); rename=t
+    }
+    next
+  }
+  /^[[:space:]]*pub[[:space:]]/ {
+    s=$0
+    if (match(s, /pub[[:space:]]+[a-z_][a-z0-9_]*/)) {
+      t=substr(s, RSTART, RLENGTH); sub(/pub[[:space:]]+/, "", t)
+      print (rename != "" ? rename : t)
+    }
+    rename=""
+  }
+' "$CONFIG_RS")"
+
+if [[ -z "$fields" ]]; then
+  echo "error: extracted no fields from $CONFIG_RS — has the struct layout changed?" >&2
+  exit 2
+fi
+
+missing=()
+while IFS= read -r field; do
+  [[ -z "$field" ]] && continue
+  # -w: whole-word match, so `url` does not match inside other identifiers.
+  if ! grep -qw -- "$field" "$DOCS"; then
+    missing+=("$field")
+  fi
+done <<< "$fields"
+
+if (( ${#missing[@]} > 0 )); then
+  echo "✗ config fields missing from $(basename "$DOCS"):" >&2
+  printf '    - %s\n' "${missing[@]}" >&2
+  echo "" >&2
+  echo "Document each flag in configuration.md (see the docs-sync rule), then re-run." >&2
+  exit 1
+fi
+
+count="$(printf '%s\n' "$fields" | grep -c .)"
+echo "✓ all $count config fields are documented in $(basename "$DOCS")"


### PR DESCRIPTION
## Summary

- **Config validation** — duplicate provider names are now a load error; references to unset `${VAR}` environment variables warn (rather than silently expanding to empty) during config load and in `rpc-plane check`. Fully hardcoded URLs reference no variable and stay warning-free.
- **Hot-reload completeness** — a provider's outbound client is rebuilt when its `http3` flag or the global pool size changes, not just on a URL change; `weight` stays routing-only. Restart-only server settings (`listen`, `metrics_listen`, `listen_backlog`, `worker_threads`) log a warning when changed. The rebuild decision is extracted into a pure, unit-tested helper.
- **Docs + CI** — `http3` (experimental) and `worker_threads` documented in `config.example.toml`; new `scripts/check-docs-coverage.sh` plus a CI job that fails when a config struct field is undocumented.

## Notes

- The CI `docs-coverage` job checks out the (private) docs repo and **skips cleanly when the `DOCS_REPO_TOKEN` secret is absent** — so fork PRs stay green. Add that secret to activate the check.
- This branch is based on the unmerged `fix/hot-path-contract-and-batch-bounding` work, so the diff against `main` currently includes that earlier commit; it drops out once that lands.

## Tests

`cargo fmt --all --check`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --all` all pass. Added tests: duplicate-name rejection, env-var expansion reporting, and six `client_rebuild_reason` cases. The docs-coverage script was verified on both its pass and fail paths.