### PR TITLE
Configurable write-method classification + per-provider method scoping

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -27,7 +27,9 @@ w_success = 0.1
 # best_score | weighted_random | failover_ordered | parallel_race
 strategy         = "best_score"
 max_retries      = 2               # retry on next-best provider on transient errors
-# broadcast_writes = false         # fan out sendTransaction to all providers
+# broadcast_writes = false         # fan out write methods to all providers
+# write_methods    = ["sendTransaction"]  # methods routed as writes (default: sendTransaction
+                                          # only; add "simulateTransaction" to broadcast it too)
 
 # ── Providers ──────────────────────────────────────────────────────────────────
 [[providers]]
@@ -46,6 +48,15 @@ name   = "triton"
 url    = "https://your-pool.rpcpool.com/${TRITON_API_KEY}"
 weight = 1
 http3  = true
+
+# Submission-only provider (e.g. a transaction-landing service). `methods`
+# scopes it to the calls it supports, so it never receives reads it can't
+# answer. Such providers are health-tracked from live request outcomes, not
+# the getSlot probe. See examples/fast-tx-landing.toml.
+# [[providers]]
+# name    = "landing-service"
+# url     = "https://fast.example/api/submit"
+# methods = ["sendTransaction"]
 
 # ── Telemetry reporting ────────────────────────────────────────────────────────
 # Presence of this block enables RemoteReporter. Absence keeps Prometheus-only mode.

--- a/examples/fast-tx-landing.toml
+++ b/examples/fast-tx-landing.toml
@@ -1,0 +1,62 @@
+# Fast transaction landing
+#
+# Maximises the probability (and speed) of landing a transaction by racing
+# sendTransaction across general RPC providers AND a submission-only landing
+# service, returning the fastest valid success.
+#
+# How it works:
+#   - broadcast_writes = true fans every write method out to all healthy
+#     providers simultaneously; the first 2xx wins, stragglers are drained in
+#     the background for health/metrics. Duplicate sends are harmless — Solana
+#     deduplicates by signature.
+#   - The "landing-service" provider is scoped with `methods = ["sendTransaction"]`.
+#     It only ever receives sendTransaction, so the reads in your app still route
+#     to the general providers and never hit an endpoint that can't serve them.
+#   - Submission-only providers can't answer the getSlot health probe, so the
+#     proxy skips probing them and scores their health from live send outcomes
+#     (the circuit still opens if sends keep failing).
+#
+# simulateTransaction is read-only and NOT broadcast here — it routes like a
+# read. Fast landing skips preflight anyway (skipPreflight = true), so there's
+# no simulation in the hot path. If you do want it broadcast, add it to
+# write_methods below.
+#
+# Usage:
+#   export HELIUS_API_KEY=...
+#   export TRITON_API_KEY=...
+#   export LANDING_API_KEY=...
+#   rpc-plane -c examples/fast-tx-landing.toml run
+
+[server]
+listen         = "127.0.0.1:9400"
+metrics_listen = "127.0.0.1:9401"
+
+[health]
+interval_ms             = 500    # probe general providers often
+slot_drift_threshold    = 3      # never route reads to a stale node
+circuit_open_failures   = 3      # fail fast
+circuit_cooldown_secs   = 10     # recover quickly
+
+[routing]
+strategy         = "best_score"          # reads go to the freshest provider
+max_retries      = 3
+broadcast_writes = true                  # race writes across every provider that supports them
+# write_methods  = ["sendTransaction"]   # default; add "simulateTransaction" to broadcast it too
+
+# General-purpose providers — serve reads and participate in the send race.
+[[providers]]
+name   = "helius"
+url    = "https://mainnet.helius-rpc.com/?api-key=${HELIUS_API_KEY}"
+weight = 1
+
+[[providers]]
+name   = "triton"
+url    = "https://your-pool.rpcpool.com/${TRITON_API_KEY}"
+weight = 1
+
+# Submission-only landing service — only ever receives sendTransaction.
+# (e.g. circular.fi / a staked-connection gateway — see https://docs.circular.fi)
+[[providers]]
+name    = "landing-service"
+url     = "https://fast.example/api/submit?api-key=${LANDING_API_KEY}"
+methods = ["sendTransaction"]

--- a/examples/trading-bot.toml
+++ b/examples/trading-bot.toml
@@ -3,14 +3,15 @@
 # Tuned for workloads that need to land transactions fast and reliably.
 #
 # Key differences from the default config:
-#   - All writes (sendTransaction) broadcast to every healthy provider
+#   - Writes (sendTransaction) broadcast to every healthy provider
 #   - Tighter health probe interval — faster detection of degraded providers
 #   - Tighter slot drift threshold — never route to a stale node
 #   - Faster circuit breaker — fail fast and failover
 #   - Reads use best_score — always go to the freshest provider
 #
-# This is the default write behaviour (broadcast is always on), but the
-# tighter health settings ensure you're broadcasting to only the best nodes.
+# Broadcasting writes is opt-in (off by default); broadcast_writes = true below
+# turns it on, and the tighter health settings keep the broadcast set to the
+# best nodes.
 #
 # Usage:
 #   export HELIUS_API_KEY=...
@@ -37,8 +38,9 @@ w_slot    = 0.4
 w_success = 0.1
 
 [routing]
-strategy    = "best_score"   # reads go to the freshest provider
-max_retries = 3              # retry aggressively on reads
+strategy         = "best_score"   # reads go to the freshest provider
+max_retries      = 3              # retry aggressively on reads
+broadcast_writes = true           # fan out sendTransaction to every healthy provider
 
 [[providers]]
 name   = "helius"

--- a/rpc-plane-core/benches/proxy_bench.rs
+++ b/rpc-plane-core/benches/proxy_bench.rs
@@ -28,6 +28,7 @@ fn prov(name: &str) -> ProviderConfig {
         url: "http://localhost:9090".to_string(),
         weight: 1,
         http3: false,
+        methods: None,
     }
 }
 
@@ -50,6 +51,10 @@ fn bench_route(c: &mut Criterion) {
         snap("alchemy", 0.5),
     ];
     let providers = vec![prov("helius"), prov("quicknode"), prov("alchemy")];
+    let writes = vec![
+        "sendTransaction".to_string(),
+        "simulateTransaction".to_string(),
+    ];
 
     let mut g = c.benchmark_group("route");
     g.bench_function("best_score/3_providers", |b| {
@@ -60,6 +65,7 @@ fn bench_route(c: &mut Criterion) {
                 black_box(&RoutingStrategy::BestScore),
                 black_box(&providers),
                 false,
+                black_box(&writes),
             )
         })
     });
@@ -71,6 +77,7 @@ fn bench_route(c: &mut Criterion) {
                 black_box(&RoutingStrategy::WeightedRandom),
                 black_box(&providers),
                 false,
+                black_box(&writes),
             )
         })
     });
@@ -82,6 +89,7 @@ fn bench_route(c: &mut Criterion) {
                 black_box(&RoutingStrategy::BestScore),
                 black_box(&providers),
                 true,
+                black_box(&writes),
             )
         })
     });

--- a/rpc-plane-core/src/config.rs
+++ b/rpc-plane-core/src/config.rs
@@ -46,7 +46,26 @@ impl Config {
                 "duplicate provider name '{}'; provider names must be unique",
                 p.name
             );
+            if let Some(methods) = &p.methods {
+                anyhow::ensure!(
+                    !methods.is_empty(),
+                    "provider '{}' has an empty methods list; omit the key to serve all methods",
+                    p.name
+                );
+                anyhow::ensure!(
+                    methods.iter().all(|m| !m.trim().is_empty()),
+                    "provider '{}' has an empty entry in methods",
+                    p.name
+                );
+            }
         }
+        anyhow::ensure!(
+            self.routing
+                .write_methods
+                .iter()
+                .all(|m| !m.trim().is_empty()),
+            "routing.write_methods must not contain empty entries"
+        );
         if let Some(r) = &self.reporting {
             anyhow::ensure!(
                 !r.endpoint.is_empty(),
@@ -234,10 +253,15 @@ pub struct RoutingConfig {
     /// Maximum provider retries on retryable errors (per request).
     #[serde(default = "default_max_retries")]
     pub max_retries: usize,
-    /// Broadcast sendTransaction / simulateTransaction to all healthy providers
-    /// simultaneously. Off by default — writes are routed like reads.
+    /// Broadcast write methods to all healthy providers simultaneously. Off by
+    /// default — writes are routed like reads (sequential failover).
     #[serde(default)]
     pub broadcast_writes: bool,
+    /// JSON-RPC methods treated as writes. Defaults to `sendTransaction` and
+    /// `simulateTransaction` so simulations route on the fast write path; override
+    /// to reclassify (e.g. drop `simulateTransaction` to route it like a read).
+    #[serde(default = "default_write_methods")]
+    pub write_methods: Vec<String>,
 }
 
 impl Default for RoutingConfig {
@@ -246,12 +270,20 @@ impl Default for RoutingConfig {
             strategy: RoutingStrategy::default(),
             max_retries: default_max_retries(),
             broadcast_writes: false,
+            write_methods: default_write_methods(),
         }
     }
 }
 
 fn default_max_retries() -> usize {
     2
+}
+
+fn default_write_methods() -> Vec<String> {
+    // simulateTransaction is read-only (no on-chain mutation) and is not in the
+    // fast-landing path, so it routes like a read by default. Add it here to have
+    // it broadcast under broadcast_writes.
+    vec!["sendTransaction".to_string()]
 }
 
 // ── Providers ───────────────────────────────────────────────────────────────
@@ -265,6 +297,25 @@ pub struct ProviderConfig {
     /// Use HTTP/3 (QUIC) for outbound connections to this provider.
     #[serde(default)]
     pub http3: bool,
+    /// Restrict this provider to a specific set of JSON-RPC methods. When unset
+    /// (the default) the provider serves every method. Set it to scope a
+    /// submission-only endpoint (e.g. a transaction-landing service that only
+    /// supports `sendTransaction`) so it never receives reads it can't answer —
+    /// `methods = ["sendTransaction"]`. Health-probed only if `getSlot` is in the
+    /// list; otherwise health is driven by real request outcomes.
+    #[serde(default)]
+    pub methods: Option<Vec<String>>,
+}
+
+impl ProviderConfig {
+    /// Whether this provider is allowed to serve `method`. Unrestricted
+    /// providers (no `methods` list) serve everything.
+    pub fn supports(&self, method: &str) -> bool {
+        match &self.methods {
+            Some(list) if !list.is_empty() => list.iter().any(|m| m == method),
+            _ => true,
+        }
+    }
 }
 
 fn default_weight() -> u32 {
@@ -394,6 +445,59 @@ url = "http://localhost:8900"
         let err = Config::load(f.path()).unwrap_err().to_string();
         assert!(err.contains("duplicate provider name"), "got: {err}");
         assert!(err.contains("helius"), "got: {err}");
+    }
+
+    #[test]
+    fn default_write_methods_is_send_only() {
+        let f = write_config(
+            r#"
+[[providers]]
+name = "p"
+url = "http://localhost:8899"
+"#,
+        );
+        let cfg = Config::load(f.path()).unwrap();
+        assert_eq!(
+            cfg.routing.write_methods,
+            vec!["sendTransaction".to_string()]
+        );
+    }
+
+    #[test]
+    fn parses_provider_methods_allowlist() {
+        let f = write_config(
+            r#"
+[[providers]]
+name = "general"
+url = "http://localhost:8899"
+
+[[providers]]
+name = "submit"
+url = "http://localhost:9000"
+methods = ["sendTransaction"]
+"#,
+        );
+        let cfg = Config::load(f.path()).unwrap();
+        let general = &cfg.providers[0];
+        let submit = &cfg.providers[1];
+        assert!(general.methods.is_none());
+        assert!(general.supports("getSlot"));
+        assert!(submit.supports("sendTransaction"));
+        assert!(!submit.supports("getSlot"));
+    }
+
+    #[test]
+    fn rejects_empty_methods_list() {
+        let f = write_config(
+            r#"
+[[providers]]
+name = "submit"
+url = "http://localhost:9000"
+methods = []
+"#,
+        );
+        let err = Config::load(f.path()).unwrap_err().to_string();
+        assert!(err.contains("empty methods list"), "got: {err}");
     }
 
     #[test]

--- a/rpc-plane-core/src/health.rs
+++ b/rpc-plane-core/src/health.rs
@@ -402,6 +402,19 @@ async fn health_loop(
     metrics: Metrics,
     stop: Arc<AtomicBool>,
 ) {
+    // Submit-only providers (e.g. a transaction-landing service scoped to
+    // `methods = ["sendTransaction"]`) can't answer the getSlot probe. Skip the
+    // probe loop for them; their health is driven entirely by real request
+    // outcomes recorded on the routing path.
+    if !provider.supports("getSlot") {
+        debug!(
+            provider = %provider.name,
+            "health probe skipped (provider does not support getSlot); \
+             health tracked via live request outcomes"
+        );
+        return;
+    }
+
     let interval = Duration::from_millis(cfg.interval_ms);
     loop {
         if stop.load(Ordering::Relaxed) {
@@ -660,6 +673,7 @@ mod tests {
             url: "http://127.0.0.1:1".to_string(),
             weight: 1,
             http3: false,
+            methods: None,
         };
         let monitor = HealthMonitor::new(
             std::slice::from_ref(&provider),
@@ -690,6 +704,7 @@ mod tests {
             url: "http://localhost:8899".to_string(),
             weight: 1,
             http3: false,
+            methods: None,
         };
         // We don't call add_provider here (needs real HTTP) — just verify map ops
         {

--- a/rpc-plane-core/src/proxy.rs
+++ b/rpc-plane-core/src/proxy.rs
@@ -181,6 +181,7 @@ async fn handle_rpc(State(state): State<ProxyState>, headers: HeaderMap, body: B
         &config.routing.strategy,
         &config.providers,
         config.routing.broadcast_writes,
+        &config.routing.write_methods,
     );
 
     let ctx = RequestCtx {

--- a/rpc-plane-core/src/router.rs
+++ b/rpc-plane-core/src/router.rs
@@ -13,10 +13,16 @@ pub enum MethodClass {
     Write,
 }
 
-pub fn classify(method: &str) -> MethodClass {
-    match method {
-        "sendTransaction" | "simulateTransaction" => MethodClass::Write,
-        _ => MethodClass::Read,
+/// Classify a method as a read or write given the configured write-method list.
+///
+/// The list is operator-controlled (`routing.write_methods`); it defaults to
+/// `sendTransaction` + `simulateTransaction` so simulations route on the fast
+/// write path, but it can be overridden to add or remove methods.
+pub fn classify(method: &str, write_methods: &[String]) -> MethodClass {
+    if write_methods.iter().any(|m| m == method) {
+        MethodClass::Write
+    } else {
+        MethodClass::Read
     }
 }
 
@@ -68,16 +74,34 @@ pub fn route(
     strategy: &RoutingStrategy,
     providers: &[ProviderConfig],
     broadcast_writes: bool,
+    write_methods: &[String],
 ) -> RouteDecision {
-    let class = classify(method);
+    let class = classify(method, write_methods);
 
-    let mut available: Vec<&HealthSnapshot> =
-        snapshots.iter().filter(|s| s.is_available()).collect();
+    // A provider serves this request only if its optional `methods` allowlist
+    // permits the method (unrestricted providers permit everything).
+    let supports = |name: &Arc<str>| {
+        providers
+            .iter()
+            .find(|p| p.name.as_str() == name.as_ref())
+            .is_none_or(|p| p.supports(method))
+    };
+
+    let mut available: Vec<&HealthSnapshot> = snapshots
+        .iter()
+        .filter(|s| s.is_available() && supports(&s.name))
+        .collect();
 
     if available.is_empty() {
-        // All circuits open: try every provider anyway — degraded but not dead.
+        // No healthy provider serves this method. Fall back to every provider
+        // that *supports* it, even circuit-open — degraded but not dead. If none
+        // support it (misconfiguration), the list is empty and the proxy errors.
         return RouteDecision {
-            providers: snapshots.iter().map(|s| s.name.clone()).collect(),
+            providers: snapshots
+                .iter()
+                .filter(|s| supports(&s.name))
+                .map(|s| s.name.clone())
+                .collect(),
             broadcast: broadcast_writes && class == MethodClass::Write,
         };
     }
@@ -223,12 +247,28 @@ mod tests {
                 url: "http://x".to_string(),
                 weight: 1,
                 http3: false,
+                methods: None,
             })
             .collect()
     }
 
     fn names(d: &RouteDecision) -> Vec<&str> {
         d.providers.iter().map(|p| p.as_ref()).collect()
+    }
+
+    /// Like `providers`, but restricts `name` to a single method (submit-only).
+    fn providers_scoped(names: &[&str], scoped: &str, method: &str) -> Vec<ProviderConfig> {
+        let mut p = providers(names);
+        for cfg in &mut p {
+            if cfg.name == scoped {
+                cfg.methods = Some(vec![method.to_string()]);
+            }
+        }
+        p
+    }
+
+    fn writes() -> Vec<String> {
+        vec!["sendTransaction".into(), "simulateTransaction".into()]
     }
 
     #[test]
@@ -240,6 +280,7 @@ mod tests {
             &RoutingStrategy::BestScore,
             &providers(&["a", "b", "c"]),
             false,
+            &writes(),
         );
         assert_eq!(&*d.providers[0], "a");
         assert_eq!(&*d.providers[1], "b");
@@ -255,6 +296,7 @@ mod tests {
             &RoutingStrategy::BestScore,
             &providers(&["a", "b"]),
             false,
+            &writes(),
         );
         assert!(!d.broadcast);
         assert_eq!(&*d.providers[0], "a");
@@ -269,6 +311,7 @@ mod tests {
             &RoutingStrategy::BestScore,
             &providers(&["a", "b"]),
             true,
+            &writes(),
         );
         assert!(d.broadcast);
         assert_eq!(d.providers.len(), 2);
@@ -283,6 +326,7 @@ mod tests {
             &RoutingStrategy::BestScore,
             &providers(&["a", "b", "c"]),
             false,
+            &writes(),
         );
         assert!(!d.providers.iter().any(|p| p.as_ref() == "b"));
     }
@@ -296,6 +340,7 @@ mod tests {
             &RoutingStrategy::BestScore,
             &providers(&["a", "b", "c"]),
             true,
+            &writes(),
         );
         assert!(!d.providers.iter().any(|p| p.as_ref() == "b"));
         assert_eq!(d.providers.len(), 2);
@@ -310,6 +355,7 @@ mod tests {
             &RoutingStrategy::BestScore,
             &providers(&["a", "b"]),
             false,
+            &writes(),
         );
         assert_eq!(d.providers.len(), 2);
     }
@@ -324,21 +370,32 @@ mod tests {
             &RoutingStrategy::FailoverOrdered,
             &cfg,
             false,
+            &writes(),
         );
         assert_eq!(names(&d), ["c", "a", "b"]);
     }
 
     #[test]
     fn classify_write_methods() {
-        assert_eq!(classify("sendTransaction"), MethodClass::Write);
-        assert_eq!(classify("simulateTransaction"), MethodClass::Write);
+        let w = writes();
+        assert_eq!(classify("sendTransaction", &w), MethodClass::Write);
+        assert_eq!(classify("simulateTransaction", &w), MethodClass::Write);
     }
 
     #[test]
     fn classify_read_methods() {
-        assert_eq!(classify("getSlot"), MethodClass::Read);
-        assert_eq!(classify("getAccountInfo"), MethodClass::Read);
-        assert_eq!(classify("getBalance"), MethodClass::Read);
+        let w = writes();
+        assert_eq!(classify("getSlot", &w), MethodClass::Read);
+        assert_eq!(classify("getAccountInfo", &w), MethodClass::Read);
+        assert_eq!(classify("getBalance", &w), MethodClass::Read);
+    }
+
+    #[test]
+    fn classify_honors_custom_write_list() {
+        // Drop simulateTransaction so simulations route like reads.
+        let w = vec!["sendTransaction".to_string()];
+        assert_eq!(classify("simulateTransaction", &w), MethodClass::Read);
+        assert_eq!(classify("sendTransaction", &w), MethodClass::Write);
     }
 
     #[test]
@@ -387,6 +444,7 @@ mod tests {
             &RoutingStrategy::ParallelRace,
             &providers(&["a", "b"]),
             false,
+            &writes(),
         );
         assert!(d.broadcast);
         assert_eq!(names(&d), ["a", "b"]);
@@ -401,9 +459,78 @@ mod tests {
             &RoutingStrategy::BestScore,
             &providers(&["a", "b"]),
             false,
+            &writes(),
         );
         assert_eq!(names(&d), ["b"]);
         assert!(!d.broadcast);
+    }
+
+    #[test]
+    fn submit_only_provider_excluded_from_reads() {
+        // "send" only supports sendTransaction; a read must not route to it.
+        let snaps = vec![snap("read", 0.9), snap("send", 0.95)];
+        let cfg = providers_scoped(&["read", "send"], "send", "sendTransaction");
+        let d = route(
+            "getSlot",
+            &snaps,
+            &RoutingStrategy::BestScore,
+            &cfg,
+            true,
+            &writes(),
+        );
+        assert_eq!(names(&d), ["read"]);
+        assert!(!d.broadcast);
+    }
+
+    #[test]
+    fn submit_only_provider_included_in_write_broadcast() {
+        let snaps = vec![snap("read", 0.9), snap("send", 0.95)];
+        let cfg = providers_scoped(&["read", "send"], "send", "sendTransaction");
+        let d = route(
+            "sendTransaction",
+            &snaps,
+            &RoutingStrategy::BestScore,
+            &cfg,
+            true,
+            &writes(),
+        );
+        assert!(d.broadcast);
+        let mut got = names(&d);
+        got.sort_unstable();
+        assert_eq!(got, ["read", "send"]);
+    }
+
+    #[test]
+    fn unsupported_method_yields_no_providers() {
+        // Only provider is submit-only; a read it can't serve routes nowhere.
+        let snaps = vec![snap("send", 0.95)];
+        let cfg = providers_scoped(&["send"], "send", "sendTransaction");
+        let d = route(
+            "getAccountInfo",
+            &snaps,
+            &RoutingStrategy::BestScore,
+            &cfg,
+            true,
+            &writes(),
+        );
+        assert!(d.providers.is_empty());
+    }
+
+    #[test]
+    fn submit_only_provider_used_when_others_open() {
+        // All circuits open: fall back to providers that support the method only.
+        let snaps = vec![snap_open("read"), snap_open("send")];
+        let cfg = providers_scoped(&["read", "send"], "send", "sendTransaction");
+        let d = route(
+            "getSlot",
+            &snaps,
+            &RoutingStrategy::BestScore,
+            &cfg,
+            true,
+            &writes(),
+        );
+        // getSlot can't go to the submit-only provider even in the degraded path.
+        assert_eq!(names(&d), ["read"]);
     }
 
     #[test]

--- a/rpc-plane-core/tests/integration.rs
+++ b/rpc-plane-core/tests/integration.rs
@@ -88,6 +88,7 @@ fn test_config(
                 url: url.to_string(),
                 weight: 1,
                 http3: false,
+                methods: None,
             })
             .collect(),
         reporting: None,
@@ -465,12 +466,14 @@ async fn circuit_recovers_traffic_resumes() {
                 url: url_a,
                 weight: 1,
                 http3: false,
+                methods: None,
             },
             ProviderConfig {
                 name: "b".into(),
                 url: url_b,
                 weight: 1,
                 http3: false,
+                methods: None,
             },
         ],
         reporting: None,

--- a/rpc-plane/src/main.rs
+++ b/rpc-plane/src/main.rs
@@ -601,6 +601,7 @@ mod tests {
             url: url.to_string(),
             weight: 1,
             http3,
+            methods: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Two related routing changes.

**Configurable write classification.** Read-vs-write classification is now driven by `routing.write_methods` (default: `["sendTransaction"]`). `simulateTransaction` is no longer a write by default — it's read-only and not in the transaction-landing path, so it routes like a read (and can be raced with `parallel_race`). Add it to `write_methods` to broadcast it under `broadcast_writes`.

**Per-provider method scoping.** New optional `methods` allowlist on a provider lets you mix in a submission-only endpoint — e.g. a transaction-landing service that only accepts `sendTransaction` — without it receiving reads it can't serve. Reads route only to providers that support them; with `broadcast_writes` a send fans out across every provider listing it, and the fastest valid success wins. Providers that don't support `getSlot` skip the health probe and are scored from live send outcomes (the circuit still opens on repeated failures).

This unlocks a "land transactions fast" setup — see the new `examples/fast-tx-landing.toml`.

## Changes

- `config`: `ProviderConfig.methods` + `ProviderConfig::supports()`; validation rejects empty `methods` lists and empty `write_methods` entries
- `router`: filter routable providers by method support in both the healthy and all-circuits-open fallback paths
- `health`: skip the `getSlot` probe loop for providers that don't support it
- `examples`: new `fast-tx-landing.toml`; fixed `trading-bot.toml`, which wrongly claimed write broadcasting was on by default
- Docs updated in the docs repo (routing/configuration/architecture)

## Compatibility

Existing `broadcast_writes` users who relied on `simulateTransaction` being broadcast must add it back to `write_methods`.

## Validation

`cargo test --all` (83 unit + 17 integration), `cargo fmt --all --check`, and `cargo clippy --all-targets` all pass. New tests cover method-support filtering (reads excluded from submit-only providers, sends included, unsupported-method → empty route, degraded fallback), the `supports()` helper, the new default, and empty-list validation.