### PR TITLE
Dependency batch bump + parallel-safe config env tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,17 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,13 +120,13 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -150,8 +139,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -165,19 +153,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -1148,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -1345,22 +1331,21 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix 0.38.44",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags",
  "hex",
@@ -1368,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -1379,7 +1364,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "procfs",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -1397,7 +1382,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1412,13 +1397,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1461,33 +1446,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1497,16 +1461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -1555,7 +1510,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1678,13 +1633,13 @@ dependencies = [
  "http-body-util",
  "parking_lot",
  "prometheus",
- "rand 0.8.6",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
  "shellexpand",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "toml",
  "tower",
@@ -1994,31 +1949,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/rpcplane/rpc-plane"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
-axum = "0.7"
+axum = "0.8"
 reqwest = { version = "=0.12.28", default-features = false, features = ["json", "rustls-tls", "http2", "http3", "gzip", "brotli", "deflate", "zstd", "charset"] }
 bytes = "1"
 serde = { version = "1", features = ["derive"] }
@@ -25,11 +25,11 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
-thiserror = "1"
+thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
-prometheus = { version = "0.13", default-features = false, features = ["process"] }
+prometheus = { version = "0.14", default-features = false, features = ["process"] }
 parking_lot = "0.12"
-rand = "0.8"
+rand = "0.9"
 shellexpand = "3"
 tempfile = "3"
 sha2 = "0.10"

--- a/rpc-plane-core/src/config.rs
+++ b/rpc-plane-core/src/config.rs
@@ -90,10 +90,23 @@ impl Config {
 /// URL (e.g. `${HELIUS_API_KY}` → `...?api-key=`). Configs that hardcode the
 /// full URL+token reference no variables and so report nothing.
 pub fn expand_env_vars(input: &str) -> (String, Vec<String>) {
+    expand_env_vars_with(input, |var| std::env::var(var).ok())
+}
+
+/// Core of [`expand_env_vars`], parameterised over the variable lookup.
+///
+/// `lookup` resolves a variable name to its value (`None` = unset). Production
+/// passes a closure over the process environment; tests pass an in-memory map so
+/// they never mutate the shared process env (which would race under the parallel
+/// test runner).
+fn expand_env_vars_with(
+    input: &str,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> (String, Vec<String>) {
     use std::cell::RefCell;
     let unset: RefCell<std::collections::BTreeSet<String>> = RefCell::new(Default::default());
     let expanded = shellexpand::env_with_context_no_errors(input, |var| {
-        Some(std::env::var(var).unwrap_or_else(|_| {
+        Some(lookup(var).unwrap_or_else(|| {
             unset.borrow_mut().insert(var.to_string());
             String::new()
         }))
@@ -538,18 +551,25 @@ methods = []
         }
     }
 
+    // The expansion logic is tested against an in-memory lookup rather than the
+    // process env: `std::env::set_var` mutates global state shared by every test
+    // in the binary, which races under the parallel runner.
+    fn lookup(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: std::collections::HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        move |var| map.get(var).cloned()
+    }
+
     #[test]
     fn expands_env_vars_braced() {
-        std::env::set_var("TEST_RPC_KEY", "abc123");
-        let f = write_config(
-            r#"
-[[providers]]
-name = "test"
-url = "https://rpc.example.com/?key=${TEST_RPC_KEY}"
-"#,
+        let (out, unset) = expand_env_vars_with(
+            "url = \"https://rpc.example.com/?key=${TEST_RPC_KEY}\"",
+            lookup(&[("TEST_RPC_KEY", "abc123")]),
         );
-        let cfg = Config::load(f.path()).unwrap();
-        assert_eq!(cfg.providers[0].url, "https://rpc.example.com/?key=abc123");
+        assert_eq!(out, "url = \"https://rpc.example.com/?key=abc123\"");
+        assert!(unset.is_empty());
     }
 
     #[test]
@@ -613,15 +633,34 @@ flush_interval_ms = 1000
 
     #[test]
     fn expands_env_vars_unbraced() {
-        std::env::set_var("TEST_UNBRACED_KEY", "xyz789");
+        let (out, unset) = expand_env_vars_with(
+            "url = \"https://rpc.example.com/?key=$TEST_UNBRACED_KEY\"",
+            lookup(&[("TEST_UNBRACED_KEY", "xyz789")]),
+        );
+        assert_eq!(out, "url = \"https://rpc.example.com/?key=xyz789\"");
+        assert!(unset.is_empty());
+    }
+
+    #[test]
+    fn unset_env_var_expands_empty_and_is_reported() {
+        let (out, unset) = expand_env_vars_with("url = \"http://x/${MISSING_VAR}\"", lookup(&[]));
+        assert_eq!(out, "url = \"http://x/\"");
+        assert_eq!(unset, vec!["MISSING_VAR".to_string()]);
+    }
+
+    // Proves the full load path applies env expansion. Uses a variable that is
+    // never set by any test (so it stays unset under parallel execution); the
+    // reference collapses to an empty string, leaving a valid non-empty URL.
+    #[test]
+    fn load_applies_env_expansion() {
         let f = write_config(
             r#"
 [[providers]]
 name = "test"
-url = "https://rpc.example.com/?key=$TEST_UNBRACED_KEY"
+url = "https://rpc.example.com/path${RPC_PLANE_UNSET_TEST_VAR}"
 "#,
         );
         let cfg = Config::load(f.path()).unwrap();
-        assert_eq!(cfg.providers[0].url, "https://rpc.example.com/?key=xyz789");
+        assert_eq!(cfg.providers[0].url, "https://rpc.example.com/path");
     }
 }

--- a/rpc-plane-core/src/router.rs
+++ b/rpc-plane-core/src/router.rs
@@ -140,7 +140,7 @@ pub fn route(
                 .collect();
 
             let total: f64 = weights.iter().sum();
-            let roll = rand::thread_rng().gen::<f64>() * total;
+            let roll = rand::rng().random::<f64>() * total;
             let mut cum = 0.0;
             let mut primary = 0;
             for (i, w) in weights.iter().enumerate() {


### PR DESCRIPTION
Milestone 3 quality items from the June audit (3.5, 3.6).

## Dependency bumps (3.6)
- **rand** 0.8→0.9 — `thread_rng().gen()` → `rng().random()` (the only call site, in `router.rs` weighted-random selection)
- **thiserror** 1→2, **axum** 0.7→0.8, **prometheus** 0.13→0.14 — no source changes required (no `:param` routes, so axum's path-syntax change doesn't apply; prometheus/thiserror APIs in use are unchanged)
- **reqwest** stays pinned `=0.12.28` — http3 still requires `--cfg reqwest_unstable` (not stabilized), so unpinning is deferred

## Config test env (3.5)
- Factored the variable lookup out of `expand_env_vars` into `expand_env_vars_with(input, lookup)`. The expansion tests now drive an in-memory map instead of `std::env::set_var`, which mutates global state shared across the parallel test runner. Added an unset-var test and a load-path test (using a never-set var) so the full `Config::load` expansion path stays covered without env mutation.

`cargo fmt` + `cargo clippy -D warnings` clean; all 85 unit + 17 integration tests pass.