### PR TITLE
chore: bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-compression"


### PR DESCRIPTION
Bumps `anyhow` 1.0.102 → 1.0.103 to resolve [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) — unsoundness in `Error::downcast_mut()`.

- Lockfile-only change; the workspace already pins `anyhow = "1"`, so no `Cargo.toml` edit was needed.
- `cargo audit` reports no warnings after the bump.
- `cargo check --workspace` passes.

Follows the same pattern as #13 (RUSTSEC-2026-0185).

🤖 Generated with [Claude Code](https://claude.com/claude-code)