### PR TITLE
fix: prevent broadcast double-execution on preflight-error legs

### DIFF
--- a/rpc-plane-core/src/proxy.rs
+++ b/rpc-plane-core/src/proxy.rs
@@ -406,14 +406,25 @@ async fn broadcast(
         });
     }
 
-    // Return on the FIRST 2xx success rather than draining the whole JoinSet —
+    // Return on the FIRST real success rather than draining the whole JoinSet —
     // otherwise client latency tracks the slowest provider, defeating the entire
-    // point of broadcast/ParallelRace. Stragglers are handed to a detached task
-    // (below) so every provider's outcome still feeds metrics and health scoring.
+    // point of broadcast/ParallelRace. A leg succeeds only on HTTP 2xx *and* a body
+    // with no JSON-RPC `error` member: a `sendTransaction` that fails preflight
+    // returns HTTP 200 + error -32002 and is the *fastest* leg precisely because it
+    // did no work — if that won the race the client would see a failure, re-sign,
+    // and double-execute while a slower provider actually landed the tx. Stragglers
+    // are handed to a detached task (below) so every provider's outcome still feeds
+    // metrics and health scoring.
+    //
+    // `best_error` keeps the most informative failed-leg body so that, if no leg
+    // succeeds, the client gets a real upstream error (a deterministic -32602/-32002
+    // it can act on) instead of a generic "all providers failed".
+    let mut best_error: Option<(u16, Bytes, u8)> = None; // (status, body, rank)
+
     while let Some(res) = set.join_next().await {
         match res {
             Ok((name, Ok((status, bytes)), latency_ms)) => {
-                let success = (200..300).contains(&status);
+                let success = leg_succeeded(status, &bytes);
                 record_broadcast_outcome(state, method, &name, success, latency_ms, count);
                 if success {
                     info!(
@@ -431,7 +442,12 @@ async fn broadcast(
                     )
                         .into_response();
                 }
-                warn!(request_id = %request_id, provider = %name, method, status, "broadcast provider non-2xx");
+                let rpc_code = extract_rpc_error_code(&bytes);
+                warn!(request_id = %request_id, provider = %name, method, status, code = ?rpc_code, "broadcast leg failed");
+                let rank = broadcast_error_rank(status, rpc_code);
+                if best_error.as_ref().is_none_or(|(_, _, best)| rank > *best) {
+                    best_error = Some((status, bytes, rank));
+                }
             }
             Ok((name, Err(e), latency_ms)) => {
                 warn!(request_id = %request_id, provider = %name, method, error = %e, "broadcast provider failed");
@@ -443,8 +459,19 @@ async fn broadcast(
         }
     }
 
-    // Reached only when no provider produced a 2xx — every outcome was already
-    // recorded synchronously above.
+    // No provider returned a real success — every outcome was already recorded
+    // synchronously above. Surface a captured upstream error body (a preflight
+    // -32002 rides on HTTP 200; a non-retryable 4xx passes its status through)
+    // rather than masking it as a generic -32603.
+    if let Some((status, bytes, _)) = best_error {
+        error!(%request_id, method, "all broadcast providers failed; returning upstream error");
+        return (
+            StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
+            [("content-type", "application/json")],
+            bytes,
+        )
+            .into_response();
+    }
     error!(%request_id, method, "all broadcast providers failed");
     json_error_response(StatusCode::BAD_GATEWAY, -32603, "all providers failed")
 }
@@ -468,6 +495,27 @@ fn record_broadcast_outcome(
     state.monitor.record(name, success, latency_ms);
 }
 
+/// A broadcast leg counts as a success only on HTTP 2xx *and* a body with no
+/// JSON-RPC `error` member. A 2xx carrying an error body — e.g. a `sendTransaction`
+/// preflight failure (-32002) — is a failed leg, not a success; see `broadcast()`.
+fn leg_succeeded(status: u16, bytes: &Bytes) -> bool {
+    (200..300).contains(&status) && extract_rpc_error_code(bytes).is_none()
+}
+
+/// Rank a failed broadcast leg for selection as the fallback error returned to the
+/// client when no leg succeeds. Higher wins. A non-retryable JSON-RPC error (bad
+/// params, failed preflight) is deterministic and identical across providers, so
+/// it's the most useful thing to hand back; a retryable RPC error is next; a bare
+/// HTTP error with no JSON-RPC body is last.
+fn broadcast_error_rank(status: u16, rpc_code: Option<i64>) -> u8 {
+    match rpc_code {
+        Some(code) if !is_retryable_rpc_code(code) => 3,
+        Some(_) => 2,
+        None if !(200..300).contains(&status) => 1,
+        None => 0,
+    }
+}
+
 /// Drain the remaining in-flight broadcast tasks in the background after the
 /// client has already been answered, so late providers still feed metrics and
 /// health. Clones only the cheap Arc-backed handles off `ProxyState`; the
@@ -486,8 +534,8 @@ fn spawn_straggler_drain(
     tokio::spawn(async move {
         while let Some(res) = set.join_next().await {
             let (name, success, latency_ms) = match res {
-                Ok((name, Ok((status, _)), latency_ms)) => {
-                    (name, (200..300).contains(&status), latency_ms)
+                Ok((name, Ok((status, bytes)), latency_ms)) => {
+                    (name, leg_succeeded(status, &bytes), latency_ms)
                 }
                 Ok((name, Err(e), latency_ms)) => {
                     warn!(request_id = %request_id, provider = %name, error = %e, "broadcast straggler failed");

--- a/rpc-plane-core/src/router.rs
+++ b/rpc-plane-core/src/router.rs
@@ -15,9 +15,10 @@ pub enum MethodClass {
 
 /// Classify a method as a read or write given the configured write-method list.
 ///
-/// The list is operator-controlled (`routing.write_methods`); it defaults to
-/// `sendTransaction` + `simulateTransaction` so simulations route on the fast
-/// write path, but it can be overridden to add or remove methods.
+/// The list is operator-controlled (`routing.write_methods`) and defaults to
+/// `["sendTransaction"]` only — `simulateTransaction` is read-only and routes
+/// like a read unless explicitly added. It can be overridden to add or remove
+/// methods.
 pub fn classify(method: &str, write_methods: &[String]) -> MethodClass {
     if write_methods.iter().any(|m| m == method) {
         MethodClass::Write

--- a/rpc-plane-core/tests/integration.rs
+++ b/rpc-plane-core/tests/integration.rs
@@ -713,6 +713,123 @@ async fn parallel_race_returns_first_success_not_slowest() {
     );
 }
 
+/// CONTRACT: on the broadcast path a leg is a success only on HTTP 2xx *and* a body
+/// with no JSON-RPC error. A `sendTransaction` that fails preflight returns HTTP 200
+/// with error -32002 and is the *fastest* leg precisely because it did no work — if
+/// that error won the race the client would see a failure, re-sign, and
+/// double-execute while a slower provider actually landed the tx. The slower real
+/// success must win.
+#[tokio::test]
+async fn broadcast_slower_success_beats_faster_preflight_error() {
+    // "err" answers immediately with a JSON-RPC preflight error (HTTP 200 + -32002).
+    // "ok" is slower but returns a real success.
+    let (url_err, _abort_err) = start_mock(Router::new().route(
+        "/",
+        post(|| async { rpc_error_response(-32002, "blockhash not found") }),
+    ))
+    .await;
+    let (url_ok, _abort_ok) = start_slow_mock(12345, Duration::from_millis(150)).await;
+
+    let mut cfg = test_config(
+        &[("err", &url_err), ("ok", &url_ok)],
+        RoutingStrategy::BestScore,
+        0,
+        5,
+    );
+    cfg.routing.broadcast_writes = true;
+    let state = ProxyState::new(cfg);
+    let router = build_router(state);
+
+    let (status, body) = proxy_request(router, SEND_TX).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body["error"].is_null(),
+        "must not return the fast preflight error — that causes re-sign/double-execute: {body}"
+    );
+    assert_eq!(
+        body["result"].as_u64(),
+        Some(12345),
+        "must return the landing provider's success"
+    );
+}
+
+/// CONTRACT: when every broadcast leg fails with a JSON-RPC error body, the proxy
+/// must surface a real upstream error (the -32002 preflight failure, which rides on
+/// HTTP 200) rather than masking it as a generic -32603 "all providers failed".
+#[tokio::test]
+async fn broadcast_all_error_bodies_passthrough_not_generic() {
+    let (url_a, _abort_a) = start_mock(Router::new().route(
+        "/",
+        post(|| async { rpc_error_response(-32002, "blockhash not found") }),
+    ))
+    .await;
+    let (url_b, _abort_b) = start_mock(Router::new().route(
+        "/",
+        post(|| async { rpc_error_response(-32002, "blockhash not found") }),
+    ))
+    .await;
+
+    let mut cfg = test_config(
+        &[("a", &url_a), ("b", &url_b)],
+        RoutingStrategy::BestScore,
+        0,
+        5,
+    );
+    cfg.routing.broadcast_writes = true;
+    let state = ProxyState::new(cfg);
+    let router = build_router(state);
+
+    let (status, body) = proxy_request(router, SEND_TX).await;
+
+    // Preflight errors are HTTP 200 with a JSON-RPC error body.
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["error"]["code"].as_i64(),
+        Some(-32002),
+        "should surface the upstream preflight error, not synthetic -32603: {body}"
+    );
+}
+
+/// CONTRACT: when no broadcast leg succeeds, the returned error prefers a
+/// deterministic client error (-32602 invalid params, identical across providers)
+/// over a transient one (-32005 node behind), regardless of arrival order.
+#[tokio::test]
+async fn broadcast_prefers_deterministic_error_over_transient() {
+    let (url_transient, _abort_t) = start_mock(Router::new().route(
+        "/",
+        post(|| async { rpc_error_response(-32005, "node is behind") }),
+    ))
+    .await;
+    let (url_deterministic, _abort_d) = start_mock(Router::new().route(
+        "/",
+        post(|| async { rpc_error_response(-32602, "invalid params") }),
+    ))
+    .await;
+
+    let mut cfg = test_config(
+        &[
+            ("transient", &url_transient),
+            ("deterministic", &url_deterministic),
+        ],
+        RoutingStrategy::BestScore,
+        0,
+        5,
+    );
+    cfg.routing.broadcast_writes = true;
+    let state = ProxyState::new(cfg);
+    let router = build_router(state);
+
+    let (status, body) = proxy_request(router, SEND_TX).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["error"]["code"].as_i64(),
+        Some(-32602),
+        "should prefer the deterministic invalid-params error: {body}"
+    );
+}
+
 /// CONTRACT: a non-retryable upstream 4xx (e.g. a revoked key → 401) must be
 /// surfaced to the client as that status, not masked as HTTP 200. Chosen
 /// semantics: pass the provider status code through to the client.


### PR DESCRIPTION
## Problem

On the broadcast path (`broadcast_writes = true` and `ParallelRace`), a provider leg was counted as a success on any HTTP 2xx status. But a `sendTransaction` that fails preflight returns **HTTP 200 with a JSON-RPC `error` (-32002)** — and is the *fastest* leg precisely because it did no work. That error could win the race and be returned to the client as a failure, while a slower provider had actually passed preflight and landed the transaction. The client then re-signs with a fresh blockhash and resubmits → **both transactions execute**. Signature dedup does not help because the client minted a new signature.

## Fix

- A broadcast leg now succeeds only on **HTTP 2xx *and* a body with no JSON-RPC `error` member**. Error-bodied legs are recorded as failures and the `JoinSet` keeps draining for a real success.
- When no leg succeeds, the most informative captured upstream error body is returned — deterministic, non-retryable codes (e.g. `-32602`/`-32002`, identical across providers) are preferred — instead of a generic `-32603 all providers failed`. A preflight `-32002` rides back on HTTP 200; a non-retryable 4xx passes its status through.
- The detached straggler drain shares the same success definition, so per-provider health scoring is independent of which leg arrives first.
- Corrected a stale doc comment on `classify()`: `write_methods` defaults to `["sendTransaction"]` only (not `sendTransaction` + `simulateTransaction`).

## Tests

Three integration tests added, all passing:
- a slower real success beats a faster preflight-error leg (the double-execution regression)
- all-error-body legs surface the real upstream error, not synthetic `-32603`
- a deterministic error (`-32602`) is preferred over a transient one (`-32005`) regardless of arrival order

`cargo fmt --all`, `cargo clippy --all-targets --all-features`, and `cargo test --all` (85 unit + 20 integration) all pass clean.