### PR TITLE
Per-commitment health probing (processed/confirmed/finalized)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -7,9 +7,11 @@ metrics_listen = "127.0.0.1:9401"
 
 # ── Health scoring ─────────────────────────────────────────────────────────────
 [health]
+# Each cycle sends 3 concurrent getSlot calls (processed/confirmed/finalized),
+# so 1000ms ≈ 3 calls/provider/second (~260k/day). Raise on strictly metered plans.
 interval_ms = 1000            # how often to probe each provider
 window_secs = 60              # sliding window for error rate
-slot_drift_threshold = 10     # slots behind tip before deprioritised
+slot_drift_threshold = 10     # slots behind tip (worst of processed/confirmed) before deprioritised
 
 # Circuit breaker: opens when consecutive_failures >= N or error_rate >= threshold
 circuit_open_failures = 5

--- a/rpc-plane-core/benches/proxy_bench.rs
+++ b/rpc-plane-core/benches/proxy_bench.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rpc_plane_core::{
     config::{ProviderConfig, RoutingStrategy},
-    health::{CircuitState, HealthSnapshot},
+    health::{CircuitState, CommitmentHealth, HealthSnapshot},
     proxy::extract_method,
     router::{extract_rpc_error_code, route},
 };
@@ -19,6 +19,9 @@ fn snap(name: &str, score: f64) -> HealthSnapshot {
         latency_ms: 10.0,
         error_rate: 0.0,
         circuit: CircuitState::Closed,
+        processed: CommitmentHealth::default(),
+        confirmed: CommitmentHealth::default(),
+        finalized: CommitmentHealth::default(),
     }
 }
 

--- a/rpc-plane-core/src/health.rs
+++ b/rpc-plane-core/src/health.rs
@@ -19,6 +19,99 @@ pub enum CircuitState {
     Open,
 }
 
+// ── Commitment isolation ─────────────────────────────────────────────────────
+
+/// The three Solana commitment levels probed each cycle. `processed` is the hot
+/// path a provider serves cheapest; `confirmed`/`finalized` can lag on an
+/// entirely different storage tier, so drift is tracked per commitment against a
+/// per-commitment tip (finalized trails ~32 slots by design — comparing it to
+/// the processed tip would make every provider look drifting).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Commitment {
+    Processed,
+    Confirmed,
+    Finalized,
+}
+
+impl Commitment {
+    /// The read commitments expected to track the tip. `finalized` is excluded:
+    /// it legitimately lags, so it feeds drift metrics but not the score.
+    const READ: [Commitment; 2] = [Commitment::Processed, Commitment::Confirmed];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Commitment::Processed => "processed",
+            Commitment::Confirmed => "confirmed",
+            Commitment::Finalized => "finalized",
+        }
+    }
+}
+
+/// Last slot a provider reported at each commitment (None until first probe).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CommitmentSlots {
+    pub processed: Option<u64>,
+    pub confirmed: Option<u64>,
+    pub finalized: Option<u64>,
+}
+
+impl CommitmentSlots {
+    fn get(&self, c: Commitment) -> Option<u64> {
+        match c {
+            Commitment::Processed => self.processed,
+            Commitment::Confirmed => self.confirmed,
+            Commitment::Finalized => self.finalized,
+        }
+    }
+
+    /// Overlay freshly-probed slots, keeping prior values for any commitment
+    /// whose probe leg failed this cycle (e.g. a stalled `finalized` backend).
+    fn merge(&mut self, new: CommitmentSlots) {
+        if new.processed.is_some() {
+            self.processed = new.processed;
+        }
+        if new.confirmed.is_some() {
+            self.confirmed = new.confirmed;
+        }
+        if new.finalized.is_some() {
+            self.finalized = new.finalized;
+        }
+    }
+}
+
+/// Network tip per commitment = max slot across all providers at that level.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SlotTips {
+    pub processed: u64,
+    pub confirmed: u64,
+    pub finalized: u64,
+}
+
+impl SlotTips {
+    fn get(&self, c: Commitment) -> u64 {
+        match c {
+            Commitment::Processed => self.processed,
+            Commitment::Confirmed => self.confirmed,
+            Commitment::Finalized => self.finalized,
+        }
+    }
+
+    fn observe(&mut self, slots: &CommitmentSlots) {
+        self.processed = self.processed.max(slots.processed.unwrap_or(0));
+        self.confirmed = self.confirmed.max(slots.confirmed.unwrap_or(0));
+        self.finalized = self.finalized.max(slots.finalized.unwrap_or(0));
+    }
+}
+
+/// Per-commitment slice of a provider's snapshot: slot, drift vs the
+/// commitment's tip, and whether that drift crossed the threshold.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CommitmentHealth {
+    pub slot: Option<u64>,
+    pub drift: u64,
+    pub is_drifting: bool,
+}
+
 // ── Per-provider health snapshot (cheap to clone and pass around) ─────────────
 
 #[derive(Debug, Clone)]
@@ -26,17 +119,24 @@ pub struct HealthSnapshot {
     pub name: Arc<str>,
     /// Normalised health score 0.0–1.0. Open circuit = 0.0.
     pub score: f64,
-    /// None until the first successful slot probe.
+    /// Last observed `processed` slot. None until the first successful probe.
     pub slot_height: Option<u64>,
-    /// Slots behind the network tip. 0 when slot_height is unknown.
+    /// Worst drift across the read commitments (processed/confirmed). 0 when no
+    /// slot data yet. This is the headline drift; per-commitment detail lives in
+    /// the `processed`/`confirmed`/`finalized` fields below.
     pub slot_drift: u64,
-    /// True when slot_drift exceeds the configured threshold.
+    /// True when a read commitment's drift exceeds the configured threshold.
     pub is_drifting: bool,
     /// EMA latency in milliseconds (0.0 = no data yet).
     pub latency_ms: f64,
     /// Error rate in the sliding window (0.0–1.0).
     pub error_rate: f64,
     pub circuit: CircuitState,
+    /// Per-commitment slot + drift. `finalized` is observed for visibility but
+    /// excluded from the score (it legitimately trails the tip).
+    pub processed: CommitmentHealth,
+    pub confirmed: CommitmentHealth,
+    pub finalized: CommitmentHealth,
 }
 
 impl HealthSnapshot {
@@ -48,7 +148,7 @@ impl HealthSnapshot {
 // ── Mutable inner state (behind RwLock) ──────────────────────────────────────
 
 struct Inner {
-    slot_height: Option<u64>,
+    slots: CommitmentSlots,
     latency_ema_ms: f64,
     consecutive_failures: u32,
     circuit: CircuitState,
@@ -60,7 +160,7 @@ struct Inner {
 impl Inner {
     fn new() -> Self {
         Self {
-            slot_height: None,
+            slots: CommitmentSlots::default(),
             latency_ema_ms: 0.0,
             consecutive_failures: 0,
             circuit: CircuitState::Closed,
@@ -105,9 +205,18 @@ impl Inner {
         }
     }
 
+    /// Worst drift across the read commitments (processed/confirmed), each
+    /// compared to its own tip. None until at least one has slot data.
+    fn worst_read_drift(&self, tips: &SlotTips) -> Option<u64> {
+        Commitment::READ
+            .into_iter()
+            .filter_map(|c| self.slots.get(c).map(|h| tips.get(c).saturating_sub(h)))
+            .max()
+    }
+
     /// Compute health score from current state.
     /// Weights are normalised so they don't need to sum to 1.0.
-    fn score(&self, slot_tip: u64, cfg: &HealthConfig) -> f64 {
+    fn score(&self, tips: &SlotTips, cfg: &HealthConfig) -> f64 {
         if self.circuit == CircuitState::Open {
             return 0.0;
         }
@@ -122,14 +231,15 @@ impl Inner {
         let error_rate = self.error_rate();
         let error_score = 1.0 - error_rate;
 
-        // Slot freshness: 0 drift → 1.0; decays as drift grows past threshold
-        let slot_score = match (self.slot_height, slot_tip) {
-            (Some(h), tip) if tip > 0 => {
-                let drift = tip.saturating_sub(h);
+        // Slot freshness: 0 drift → 1.0; decays as drift grows past threshold.
+        // Scored off the worst read commitment so a provider whose `confirmed`
+        // stalls while `processed` stays fresh is still demoted.
+        let slot_score = match self.worst_read_drift(tips) {
+            Some(drift) => {
                 let thr = cfg.slot_drift_threshold as f64;
                 thr / (thr + drift as f64)
             }
-            _ => 0.5, // no data yet
+            None => 0.5, // no data yet
         };
 
         // Recent success rate (same window, same metric as error but named separately
@@ -165,24 +275,37 @@ impl ProviderHealth {
     }
 
     /// Read-only snapshot for routing decisions.
-    pub fn snapshot(&self, slot_tip: u64, cfg: &HealthConfig) -> HealthSnapshot {
+    pub fn snapshot(&self, tips: &SlotTips, cfg: &HealthConfig) -> HealthSnapshot {
         let g = self.inner.read();
-        let (slot_drift, is_drifting) = match g.slot_height {
+        let commitment = |c: Commitment| match g.slots.get(c) {
             Some(h) => {
-                let drift = slot_tip.saturating_sub(h);
-                (drift, drift > cfg.slot_drift_threshold)
+                let drift = tips.get(c).saturating_sub(h);
+                CommitmentHealth {
+                    slot: Some(h),
+                    drift,
+                    is_drifting: drift > cfg.slot_drift_threshold,
+                }
             }
-            None => (0, false),
+            None => CommitmentHealth::default(),
         };
+        let processed = commitment(Commitment::Processed);
+        let confirmed = commitment(Commitment::Confirmed);
+        let finalized = commitment(Commitment::Finalized);
+        // Headline drift = worst of the read commitments (finalized excluded).
+        let slot_drift = processed.drift.max(confirmed.drift);
+        let is_drifting = processed.is_drifting || confirmed.is_drifting;
         HealthSnapshot {
             name: self.name.clone(),
-            score: g.score(slot_tip, cfg),
-            slot_height: g.slot_height,
+            score: g.score(tips, cfg),
+            slot_height: processed.slot,
             slot_drift,
             is_drifting,
             latency_ms: g.latency_ema_ms,
             error_rate: g.error_rate(),
             circuit: g.circuit.clone(),
+            processed,
+            confirmed,
+            finalized,
         }
     }
 
@@ -193,8 +316,14 @@ impl ProviderHealth {
         apply_circuit_transitions(&mut g, &self.name, cfg);
     }
 
+    /// Convenience: set only the `processed` slot (single-commitment callers).
     pub fn update_slot(&self, slot: u64) {
-        self.inner.write().slot_height = Some(slot);
+        self.inner.write().slots.processed = Some(slot);
+    }
+
+    /// Merge a freshly-probed set of per-commitment slots.
+    pub fn update_slots(&self, slots: CommitmentSlots) {
+        self.inner.write().slots.merge(slots);
     }
 }
 
@@ -337,14 +466,18 @@ impl HealthMonitor {
         });
     }
 
-    /// Network tip = max slot height across all providers.
+    /// Per-commitment network tips = max slot across all providers at each level.
+    pub fn slot_tips(&self) -> SlotTips {
+        let mut tips = SlotTips::default();
+        for e in self.entries.read().values() {
+            tips.observe(&e.health.inner.read().slots);
+        }
+        tips
+    }
+
+    /// Network tip at `processed` = max processed slot across all providers.
     pub fn slot_tip(&self) -> u64 {
-        self.entries
-            .read()
-            .values()
-            .filter_map(|e| e.health.inner.read().slot_height)
-            .max()
-            .unwrap_or(0)
+        self.slot_tips().processed
     }
 
     /// Current snapshot for every provider. Hot path:
@@ -359,12 +492,14 @@ impl HealthMonitor {
             .values()
             .map(|e| e.health.clone())
             .collect();
-        let tip = healths
+        let mut tips = SlotTips::default();
+        for h in &healths {
+            tips.observe(&h.inner.read().slots);
+        }
+        healths
             .iter()
-            .filter_map(|h| h.inner.read().slot_height)
-            .max()
-            .unwrap_or(0);
-        healths.iter().map(|h| h.snapshot(tip, &self.cfg)).collect()
+            .map(|h| h.snapshot(&tips, &self.cfg))
+            .collect()
     }
 
     /// Update the cached slot height for a named provider.
@@ -422,14 +557,21 @@ async fn health_loop(
         }
         let t0 = Instant::now();
         match probe(&client, &provider).await {
-            Ok(slot) => {
-                let ms = t0.elapsed().as_secs_f64() * 1000.0;
-                state.update_slot(slot);
+            Ok(res) => {
+                // Score latency off the `processed` call alone — confirmed/finalized
+                // hit slower storage tiers and would inflate the EMA.
+                let ms = res.processed_latency_ms;
+                let confirmed = res.slots.confirmed;
+                let finalized = res.slots.finalized;
+                let processed = res.slots.processed.unwrap_or_default();
+                state.update_slots(res.slots);
                 state.record(true, ms, &cfg);
                 metrics.record_probe(&provider.name, "health", "ok");
                 debug!(
                     provider = %provider.name,
-                    slot,
+                    processed,
+                    confirmed = ?confirmed,
+                    finalized = ?finalized,
                     latency_ms = format!("{ms:.1}"),
                     "health probe ok"
                 );
@@ -448,12 +590,50 @@ async fn health_loop(
     }
 }
 
-async fn probe(client: &Client, provider: &ProviderConfig) -> anyhow::Result<u64> {
+/// Result of one probe cycle: the per-commitment slots plus the latency of the
+/// `processed` call (the liveness signal used for scoring).
+struct ProbeResult {
+    slots: CommitmentSlots,
+    processed_latency_ms: f64,
+}
+
+/// Probe a provider's slot at all three commitments.
+///
+/// Three separate `getSlot` requests are issued *concurrently* rather than as a
+/// JSON-RPC batch. Batches can traverse extra provider-side machinery (batch
+/// splitting at the load balancer, an un-batching hop) and some providers cap or
+/// disable them; single requests reuse the warm connection pool and mirror the
+/// shape of real client traffic. `processed` is the liveness signal — the probe
+/// fails only if it fails; a stalled `confirmed`/`finalized` surfaces as drift,
+/// not a probe error (its slot is simply left unchanged this cycle).
+async fn probe(client: &Client, provider: &ProviderConfig) -> anyhow::Result<ProbeResult> {
+    let (processed, confirmed, finalized) = tokio::join!(
+        get_slot(client, provider, Commitment::Processed),
+        get_slot(client, provider, Commitment::Confirmed),
+        get_slot(client, provider, Commitment::Finalized),
+    );
+    let (processed_slot, processed_latency_ms) = processed?;
+    Ok(ProbeResult {
+        slots: CommitmentSlots {
+            processed: Some(processed_slot),
+            confirmed: confirmed.ok().map(|(s, _)| s),
+            finalized: finalized.ok().map(|(s, _)| s),
+        },
+        processed_latency_ms,
+    })
+}
+
+/// Single `getSlot` at one commitment. Returns the slot and its round-trip ms.
+async fn get_slot(
+    client: &Client,
+    provider: &ProviderConfig,
+    commitment: Commitment,
+) -> anyhow::Result<(u64, f64)> {
     let body = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
         "method": "getSlot",
-        "params": [{"commitment": "processed"}]
+        "params": [{"commitment": commitment.as_str()}]
     });
     let mut req = client
         .post(&provider.url)
@@ -463,12 +643,15 @@ async fn probe(client: &Client, provider: &ProviderConfig) -> anyhow::Result<u64
     if provider.http3 {
         req = req.version(reqwest::Version::HTTP_3);
     }
+    let t0 = Instant::now();
     let resp = req.send().await?;
+    let ms = t0.elapsed().as_secs_f64() * 1000.0;
     anyhow::ensure!(resp.status().is_success(), "HTTP {}", resp.status());
     let json: Value = resp.json().await?;
-    json["result"]
+    let slot = json["result"]
         .as_u64()
-        .ok_or_else(|| anyhow::anyhow!("unexpected getSlot response"))
+        .ok_or_else(|| anyhow::anyhow!("unexpected getSlot response"))?;
+    Ok((slot, ms))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -481,10 +664,20 @@ mod tests {
         HealthConfig::default()
     }
 
+    /// Uniform tip across all commitments — for tests that only exercise the
+    /// (single-commitment) `processed` slot via `update_slot`.
+    fn tips(slot: u64) -> SlotTips {
+        SlotTips {
+            processed: slot,
+            confirmed: slot,
+            finalized: slot,
+        }
+    }
+
     #[test]
     fn score_unknown_provider_is_midpoint() {
         let inner = Inner::new();
-        let score = inner.score(0, &default_cfg());
+        let score = inner.score(&tips(0), &default_cfg());
         // latency=0.5, error=1.0, slot=0.5, success=1.0 → weighted average
         assert!(score > 0.0 && score < 1.0, "score={score}");
     }
@@ -493,7 +686,7 @@ mod tests {
     fn score_open_circuit_is_zero() {
         let mut inner = Inner::new();
         inner.circuit = CircuitState::Open;
-        assert_eq!(inner.score(100, &default_cfg()), 0.0);
+        assert_eq!(inner.score(&tips(100), &default_cfg()), 0.0);
     }
 
     #[test]
@@ -503,17 +696,17 @@ mod tests {
         let mut high_lat = Inner::new();
         high_lat.latency_ema_ms = 800.0;
         let cfg = default_cfg();
-        assert!(low_lat.score(100, &cfg) > high_lat.score(100, &cfg));
+        assert!(low_lat.score(&tips(100), &cfg) > high_lat.score(&tips(100), &cfg));
     }
 
     #[test]
     fn score_decreases_with_slot_drift() {
         let mut fresh = Inner::new();
-        fresh.slot_height = Some(1000);
+        fresh.slots.processed = Some(1000);
         let mut stale = Inner::new();
-        stale.slot_height = Some(950); // 50 slots behind
+        stale.slots.processed = Some(950); // 50 slots behind
         let cfg = default_cfg(); // drift_threshold = 10
-        assert!(fresh.score(1000, &cfg) > stale.score(1000, &cfg));
+        assert!(fresh.score(&tips(1000), &cfg) > stale.score(&tips(1000), &cfg));
     }
 
     #[test]
@@ -542,7 +735,7 @@ mod tests {
         for _ in 0..3 {
             ph.record(false, 0.0, &cfg);
         }
-        let snap = ph.snapshot(0, &cfg);
+        let snap = ph.snapshot(&tips(0), &cfg);
         assert_eq!(snap.circuit, CircuitState::Open);
         assert!(!snap.is_available());
     }
@@ -553,11 +746,11 @@ mod tests {
         ph.update_slot(980);
         let cfg = default_cfg(); // slot_drift_threshold = 10
 
-        let snap = ph.snapshot(1000, &cfg);
+        let snap = ph.snapshot(&tips(1000), &cfg);
         assert_eq!(snap.slot_drift, 20);
         assert!(snap.is_drifting);
 
-        let snap = ph.snapshot(985, &cfg);
+        let snap = ph.snapshot(&tips(985), &cfg);
         assert_eq!(snap.slot_drift, 5);
         assert!(!snap.is_drifting);
     }
@@ -597,14 +790,14 @@ mod tests {
         for _ in 0..10 {
             good.push_result(true, 50.0, cfg.window_secs);
         }
-        assert!(good.score(100, &cfg) > bad.score(100, &cfg));
+        assert!(good.score(&tips(100), &cfg) > bad.score(&tips(100), &cfg));
     }
 
     #[test]
     fn not_drifting_when_no_slot_data() {
         let ph = ProviderHealth::new("test");
-        // slot_height = None (no probe received yet)
-        let snap = ph.snapshot(1000, &default_cfg());
+        // slots all None (no probe received yet)
+        let snap = ph.snapshot(&tips(1000), &default_cfg());
         assert!(snap.slot_height.is_none());
         assert_eq!(snap.slot_drift, 0);
         assert!(!snap.is_drifting);
@@ -622,7 +815,7 @@ mod tests {
         for _ in 0..4 {
             ph.record(false, 0.0, &cfg);
         }
-        let snap = ph.snapshot(0, &cfg);
+        let snap = ph.snapshot(&tips(0), &cfg);
         assert_eq!(snap.circuit, CircuitState::Closed);
     }
 
@@ -637,16 +830,16 @@ mod tests {
             ..Default::default()
         };
         ph.record(false, 0.0, &cfg);
-        assert_eq!(ph.snapshot(0, &cfg).circuit, CircuitState::Open);
+        assert_eq!(ph.snapshot(&tips(0), &cfg).circuit, CircuitState::Open);
 
         // record() with cooldown=0: Open → HalfOpen (elapsed ≥ 0 always true)
         ph.record(true, 10.0, &cfg);
-        assert_eq!(ph.snapshot(0, &cfg).circuit, CircuitState::HalfOpen);
+        assert_eq!(ph.snapshot(&tips(0), &cfg).circuit, CircuitState::HalfOpen);
 
         // Probe success → Closed
         ph.record(true, 10.0, &cfg);
-        assert_eq!(ph.snapshot(0, &cfg).circuit, CircuitState::Closed);
-        assert!(ph.snapshot(0, &cfg).is_available());
+        assert_eq!(ph.snapshot(&tips(0), &cfg).circuit, CircuitState::Closed);
+        assert!(ph.snapshot(&tips(0), &cfg).is_available());
     }
 
     #[test]
@@ -660,10 +853,10 @@ mod tests {
         };
         ph.record(false, 0.0, &cfg); // Closed → Open
         ph.record(false, 0.0, &cfg); // Open → HalfOpen (cooldown=0)
-        assert_eq!(ph.snapshot(0, &cfg).circuit, CircuitState::HalfOpen);
+        assert_eq!(ph.snapshot(&tips(0), &cfg).circuit, CircuitState::HalfOpen);
         ph.record(false, 0.0, &cfg); // HalfOpen → Open (probe failed)
-        assert_eq!(ph.snapshot(0, &cfg).circuit, CircuitState::Open);
-        assert!(!ph.snapshot(0, &cfg).is_available());
+        assert_eq!(ph.snapshot(&tips(0), &cfg).circuit, CircuitState::Open);
+        assert!(!ph.snapshot(&tips(0), &cfg).is_available());
     }
 
     #[test]
@@ -787,5 +980,137 @@ mod tests {
             inner.error_rate() >= 0.0 && inner.error_rate() <= 1.0,
             "error_rate must remain a valid probability"
         );
+    }
+
+    // ── Commitment isolation ──────────────────────────────────────────────────
+
+    #[test]
+    fn finalized_drift_measured_against_finalized_tip() {
+        let ph = ProviderHealth::new("p");
+        ph.update_slots(CommitmentSlots {
+            processed: Some(1000),
+            confirmed: Some(998),
+            finalized: Some(968), // ~32 behind processed by design, but at the finalized tip
+        });
+        let t = SlotTips {
+            processed: 1000,
+            confirmed: 1000,
+            finalized: 968,
+        };
+        let snap = ph.snapshot(&t, &default_cfg()); // threshold 10
+                                                    // Against the *finalized* tip it is not behind at all — comparing it
+                                                    // to the processed tip (1000) would falsely show a 32-slot lag.
+        assert_eq!(snap.finalized.drift, 0);
+        assert!(!snap.finalized.is_drifting);
+        // Headline drift folds processed(0) + confirmed(2) but never finalized.
+        assert_eq!(snap.slot_drift, 2);
+        assert!(!snap.is_drifting);
+    }
+
+    #[test]
+    fn confirmed_stall_demotes_score_and_flags_drift() {
+        let cfg = default_cfg(); // threshold 10
+        let t = SlotTips {
+            processed: 1000,
+            confirmed: 1000,
+            finalized: 968,
+        };
+
+        // Fresh at both read commitments.
+        let healthy = ProviderHealth::new("healthy");
+        healthy.update_slots(CommitmentSlots {
+            processed: Some(1000),
+            confirmed: Some(999),
+            finalized: Some(968),
+        });
+
+        // processed fresh, but confirmed frozen 40 slots back — the failure the
+        // single processed probe could never see.
+        let stalled = ProviderHealth::new("stalled");
+        stalled.update_slots(CommitmentSlots {
+            processed: Some(1000),
+            confirmed: Some(960),
+            finalized: Some(968),
+        });
+
+        let hs = healthy.snapshot(&t, &cfg);
+        let ss = stalled.snapshot(&t, &cfg);
+
+        assert!(!hs.is_drifting);
+        assert!(ss.confirmed.is_drifting, "confirmed 40 behind must flag");
+        assert!(ss.is_drifting, "headline drift folds confirmed");
+        assert_eq!(ss.slot_drift, 40);
+        assert!(
+            ss.score < hs.score,
+            "a stalled confirmed pipeline must score below a healthy one \
+             (stalled={}, healthy={})",
+            ss.score,
+            hs.score
+        );
+    }
+
+    #[test]
+    fn slot_tips_are_computed_per_commitment() {
+        let monitor = HealthMonitor::new(&[], HealthConfig::default(), Metrics::new());
+        let insert = |name: &str, slots: CommitmentSlots| {
+            let health = ProviderHealth::new(name);
+            health.update_slots(slots);
+            monitor.entries.write().insert(
+                name.to_string(),
+                ProviderEntry {
+                    health,
+                    stop: Arc::new(AtomicBool::new(false)),
+                },
+            );
+        };
+        insert(
+            "a",
+            CommitmentSlots {
+                processed: Some(1000),
+                confirmed: Some(990),
+                finalized: Some(950),
+            },
+        );
+        insert(
+            "b",
+            CommitmentSlots {
+                processed: Some(998),
+                confirmed: Some(995),
+                finalized: Some(970),
+            },
+        );
+        let tips = monitor.slot_tips();
+        assert_eq!(tips.processed, 1000, "max processed from a");
+        assert_eq!(tips.confirmed, 995, "max confirmed from b");
+        assert_eq!(tips.finalized, 970, "max finalized from b");
+        assert_eq!(monitor.slot_tip(), 1000);
+    }
+
+    #[test]
+    fn update_slots_merges_partial_probe() {
+        let ph = ProviderHealth::new("p");
+        ph.update_slots(CommitmentSlots {
+            processed: Some(1000),
+            confirmed: Some(990),
+            finalized: Some(950),
+        });
+        // A later probe returns only processed (confirmed/finalized legs failed).
+        ph.update_slots(CommitmentSlots {
+            processed: Some(1005),
+            ..Default::default()
+        });
+        let t = SlotTips {
+            processed: 1005,
+            confirmed: 990,
+            finalized: 950,
+        };
+        let snap = ph.snapshot(&t, &default_cfg());
+        assert_eq!(snap.processed.slot, Some(1005));
+        assert_eq!(
+            snap.confirmed.slot,
+            Some(990),
+            "prior confirmed retained across a partial probe"
+        );
+        assert_eq!(snap.finalized.slot, Some(950));
     }
 }

--- a/rpc-plane-core/src/metrics.rs
+++ b/rpc-plane-core/src/metrics.rs
@@ -15,6 +15,8 @@ struct Inner {
     health_score: GaugeVec,
     slot_height: GaugeVec,
     slot_drift: GaugeVec,
+    slot_height_commitment: GaugeVec,
+    slot_drift_commitment: GaugeVec,
     circuit_state: GaugeVec,
 }
 
@@ -85,8 +87,29 @@ impl Metrics {
         .unwrap();
 
         let slot_drift = GaugeVec::new(
-            Opts::new("rpc_plane_slot_drift", "Slots behind the network tip"),
+            Opts::new(
+                "rpc_plane_slot_drift",
+                "Slots behind the network tip (worst of processed/confirmed)",
+            ),
             &["provider"],
+        )
+        .unwrap();
+
+        let slot_height_commitment = GaugeVec::new(
+            Opts::new(
+                "rpc_plane_provider_slot_height_commitment",
+                "Slot height reported by provider, per commitment level",
+            ),
+            &["provider", "commitment"],
+        )
+        .unwrap();
+
+        let slot_drift_commitment = GaugeVec::new(
+            Opts::new(
+                "rpc_plane_slot_drift_commitment",
+                "Slots behind the per-commitment network tip",
+            ),
+            &["provider", "commitment"],
         )
         .unwrap();
 
@@ -121,6 +144,8 @@ impl Metrics {
             Box::new(health_score.clone()),
             Box::new(slot_height.clone()),
             Box::new(slot_drift.clone()),
+            Box::new(slot_height_commitment.clone()),
+            Box::new(slot_drift_commitment.clone()),
             Box::new(circuit_state.clone()),
             Box::new(build_info.clone()),
         ] {
@@ -143,6 +168,8 @@ impl Metrics {
             health_score,
             slot_height,
             slot_drift,
+            slot_height_commitment,
+            slot_drift_commitment,
             circuit_state,
         }))
     }
@@ -210,6 +237,28 @@ impl Metrics {
             .circuit_state
             .with_label_values(&[provider])
             .set(if circuit_open { 1.0 } else { 0.0 });
+    }
+
+    /// Push per-commitment slot height and drift for one provider. Skipped for a
+    /// commitment with no observed slot yet (leaves the series absent rather than
+    /// emitting a misleading 0).
+    pub fn update_provider_commitment(
+        &self,
+        provider: &str,
+        commitment: &str,
+        slot: Option<u64>,
+        drift: u64,
+    ) {
+        if let Some(s) = slot {
+            self.0
+                .slot_height_commitment
+                .with_label_values(&[provider, commitment])
+                .set(s as f64);
+            self.0
+                .slot_drift_commitment
+                .with_label_values(&[provider, commitment])
+                .set(drift as f64);
+        }
     }
 
     /// Render all registered metrics in Prometheus text exposition format.
@@ -298,6 +347,26 @@ mod tests {
         let text = m.render();
         assert!(text.contains("rpc_plane_provider_health_score{provider=\"helius\"} 0.95"));
         assert!(text.contains("rpc_plane_circuit_breaker_state{provider=\"helius\"} 0"));
+    }
+
+    #[test]
+    fn per_commitment_gauges_update() {
+        let m = Metrics::new();
+        m.update_provider_commitment("helius", "confirmed", Some(300_000_000), 4);
+        // A commitment with no slot yet emits nothing.
+        m.update_provider_commitment("helius", "finalized", None, 0);
+
+        let text = m.render();
+        assert!(text.contains(
+            "rpc_plane_provider_slot_height_commitment{commitment=\"confirmed\",provider=\"helius\"} 300000000"
+        ));
+        assert!(text.contains(
+            "rpc_plane_slot_drift_commitment{commitment=\"confirmed\",provider=\"helius\"} 4"
+        ));
+        assert!(
+            !text.contains("commitment=\"finalized\""),
+            "no series should be emitted for a commitment without data"
+        );
     }
 
     #[test]

--- a/rpc-plane-core/src/proxy.rs
+++ b/rpc-plane-core/src/proxy.rs
@@ -1,5 +1,5 @@
 use crate::config::{Config, ProviderConfig};
-use crate::health::{CircuitState, HealthMonitor};
+use crate::health::{CircuitState, CommitmentHealth, HealthMonitor};
 use crate::metrics::Metrics;
 use crate::router::{extract_rpc_error_code, is_retryable_http, is_retryable_rpc_code, route};
 use crate::telemetry::{NoopReporter, Reporter, TelemetryEvent};
@@ -124,6 +124,13 @@ pub fn build_metrics_router(state: ProxyState) -> Router {
 
 async fn handle_health(State(state): State<ProxyState>) -> impl IntoResponse {
     let snaps = state.monitor.snapshots();
+    let commitment = |c: &CommitmentHealth| {
+        serde_json::json!({
+            "slot": c.slot,
+            "drift": c.drift,
+            "is_drifting": c.is_drifting,
+        })
+    };
     let providers: Vec<_> = snaps
         .iter()
         .map(|s| {
@@ -137,6 +144,11 @@ async fn handle_health(State(state): State<ProxyState>) -> impl IntoResponse {
                 "error_rate": (s.error_rate * 1000.0).round() / 1000.0,
                 "circuit": format!("{:?}", s.circuit).to_lowercase(),
                 "available": s.is_available(),
+                "commitments": {
+                    "processed": commitment(&s.processed),
+                    "confirmed": commitment(&s.confirmed),
+                    "finalized": commitment(&s.finalized),
+                },
             })
         })
         .collect();
@@ -157,6 +169,15 @@ async fn handle_metrics(State(state): State<ProxyState>) -> impl IntoResponse {
             s.slot_drift,
             s.circuit == CircuitState::Open,
         );
+        for (level, ch) in [
+            ("processed", &s.processed),
+            ("confirmed", &s.confirmed),
+            ("finalized", &s.finalized),
+        ] {
+            state
+                .metrics
+                .update_provider_commitment(s.name.as_ref(), level, ch.slot, ch.drift);
+        }
     }
     (
         [(

--- a/rpc-plane-core/src/router.rs
+++ b/rpc-plane-core/src/router.rs
@@ -211,7 +211,7 @@ pub fn route(
 mod tests {
     use super::*;
     use crate::config::ProviderConfig;
-    use crate::health::CircuitState;
+    use crate::health::{CircuitState, CommitmentHealth};
 
     fn snap(name: &str, score: f64) -> HealthSnapshot {
         HealthSnapshot {
@@ -223,6 +223,9 @@ mod tests {
             latency_ms: 50.0,
             error_rate: 0.0,
             circuit: CircuitState::Closed,
+            processed: CommitmentHealth::default(),
+            confirmed: CommitmentHealth::default(),
+            finalized: CommitmentHealth::default(),
         }
     }
 
@@ -236,6 +239,9 @@ mod tests {
             latency_ms: 0.0,
             error_rate: 1.0,
             circuit: CircuitState::Open,
+            processed: CommitmentHealth::default(),
+            confirmed: CommitmentHealth::default(),
+            finalized: CommitmentHealth::default(),
         }
     }
 


### PR DESCRIPTION
## Summary

Health probing tracked a single `getSlot processed` per provider. A provider whose optimistic-confirmation pipeline stalls keeps advancing `processed` while `confirmed` freezes — the probe saw a fresh node while every `confirmed` read served increasingly stale state. This adds per-commitment isolation.

- **Three concurrent `getSlot` requests per cycle** (processed/confirmed/finalized), issued as individual requests rather than a JSON-RPC batch. Batches can traverse extra provider-side processing; single requests reuse the warm connection pool and mirror real traffic. Latency is scored off the `processed` call alone so slower storage tiers don't inflate the EMA.
- **Per-commitment network tips.** Drift compares `finalized` against the `finalized` tip, not `processed` — otherwise every provider looks ~32 slots behind by design.
- **Slot score = worst of processed/confirmed drift**, so a stalled `confirmed` pipeline demotes a provider even when `processed` is fresh. `finalized` drift is exported for visibility but excluded from scoring.
- **Observability:** `/health` gains a per-commitment `commitments` block; new `rpc_plane_provider_slot_height_commitment` and `rpc_plane_slot_drift_commitment` gauges (labeled by `commitment`). Existing `rpc_plane_slot_drift` now reports the worst of processed/confirmed.

Probe cost on metered plans: 3 `getSlot` calls/provider/second (~260k/provider/day); raise `health.interval_ms` to reduce. Documented in `config.example.toml` and the docs site.

## Tests

`cargo fmt`, `cargo clippy --all-targets`, and `cargo test --all` all pass. Added unit coverage for per-commitment tips, finalized-drift-vs-finalized-tip, a stalled-confirmed provider scoring below a healthy one, partial-probe merge, and the per-commitment gauges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)