### PR TITLE
Stop client 4xx and 429s from breaking provider health

### DIFF
--- a/rpc-plane-core/src/health.rs
+++ b/rpc-plane-core/src/health.rs
@@ -19,6 +19,20 @@ pub enum CircuitState {
     Open,
 }
 
+/// One outcome in a provider's sliding health window.
+///
+/// `Throttle` (HTTP 429) is deliberately distinct from `Failure`: a rate limit is
+/// a load signal, not a fault. It demotes the score (so traffic sheds to peers)
+/// but is neutral to the circuit breaker — a throttled-but-healthy provider stays
+/// eligible and reabsorbs load the instant the burst passes, instead of being
+/// excluded for a full cooldown and cascading its traffic onto everyone else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Sample {
+    Success,
+    Failure,
+    Throttle,
+}
+
 // ── Commitment isolation ─────────────────────────────────────────────────────
 
 /// The three Solana commitment levels probed each cycle. `processed` is the hot
@@ -153,8 +167,8 @@ struct Inner {
     consecutive_failures: u32,
     circuit: CircuitState,
     circuit_opened_at: Option<Instant>,
-    // (timestamp, success) pairs for the sliding window
-    window: VecDeque<(Instant, bool)>,
+    // (timestamp, outcome) pairs for the sliding window
+    window: VecDeque<(Instant, Sample)>,
 }
 
 impl Inner {
@@ -181,28 +195,67 @@ impl Inner {
         }
     }
 
+    /// Fraction of non-successful outcomes in the window — hard failures **and**
+    /// throttles. Drives the health *score*, so a rate-limited provider is demoted
+    /// and best-score routing sheds its traffic to peers with headroom.
     fn error_rate(&self) -> f64 {
         if self.window.is_empty() {
             return 0.0;
         }
-        let failures = self.window.iter().filter(|(_, ok)| !ok).count();
-        failures as f64 / self.window.len() as f64
+        let bad = self
+            .window
+            .iter()
+            .filter(|(_, s)| *s != Sample::Success)
+            .count();
+        bad as f64 / self.window.len() as f64
     }
 
-    fn push_result(&mut self, success: bool, latency_ms: f64, window_secs: u64) {
-        self.prune_window(window_secs);
-        self.window.push_back((Instant::now(), success));
-        if success {
-            if self.latency_ema_ms == 0.0 {
-                self.latency_ema_ms = latency_ms;
-            } else {
-                // α = 0.15 — stable EMA, not too slow to adapt
-                self.latency_ema_ms = 0.85 * self.latency_ema_ms + 0.15 * latency_ms;
-            }
-            self.consecutive_failures = 0;
-        } else {
-            self.consecutive_failures += 1;
+    /// Fraction of *hard* failures in the window — throttles excluded. Drives the
+    /// circuit *breaker*, so a 429 storm never trips a healthy-but-capped provider
+    /// open (which would exclude it for the full cooldown and cascade load).
+    fn hard_error_rate(&self) -> f64 {
+        if self.window.is_empty() {
+            return 0.0;
         }
+        let hard = self
+            .window
+            .iter()
+            .filter(|(_, s)| *s == Sample::Failure)
+            .count();
+        hard as f64 / self.window.len() as f64
+    }
+
+    fn push_sample(&mut self, sample: Sample, latency_ms: f64, window_secs: u64) {
+        self.prune_window(window_secs);
+        self.window.push_back((Instant::now(), sample));
+        match sample {
+            Sample::Success => {
+                if self.latency_ema_ms == 0.0 {
+                    self.latency_ema_ms = latency_ms;
+                } else {
+                    // α = 0.15 — stable EMA, not too slow to adapt
+                    self.latency_ema_ms = 0.85 * self.latency_ema_ms + 0.15 * latency_ms;
+                }
+                self.consecutive_failures = 0;
+            }
+            // Hard failure: extend the consecutive-failure streak that trips the circuit.
+            Sample::Failure => self.consecutive_failures += 1,
+            // Throttle (429): neutral to the circuit — it neither extends nor resets
+            // the hard-failure streak, and does not move the latency EMA (a fast 429
+            // would otherwise flatter the provider). It only lands in the window,
+            // demoting the score via `error_rate`.
+            Sample::Throttle => {}
+        }
+    }
+
+    /// Back-compat helper: push a boolean success/failure sample.
+    fn push_result(&mut self, success: bool, latency_ms: f64, window_secs: u64) {
+        let sample = if success {
+            Sample::Success
+        } else {
+            Sample::Failure
+        };
+        self.push_sample(sample, latency_ms, window_secs);
     }
 
     /// Worst drift across the read commitments (processed/confirmed), each
@@ -316,6 +369,15 @@ impl ProviderHealth {
         apply_circuit_transitions(&mut g, &self.name, cfg);
     }
 
+    /// Record a rate-limit (HTTP 429) outcome. Demotes the score so traffic sheds
+    /// to peers, but stays neutral to the circuit breaker — the provider is
+    /// healthy, just capped, so opening it would only make the overload worse.
+    pub fn record_throttled(&self, latency_ms: f64, cfg: &HealthConfig) {
+        let mut g = self.inner.write();
+        g.push_sample(Sample::Throttle, latency_ms, cfg.window_secs);
+        apply_circuit_transitions(&mut g, &self.name, cfg);
+    }
+
     /// Convenience: set only the `processed` slot (single-commitment callers).
     pub fn update_slot(&self, slot: u64) {
         self.inner.write().slots.processed = Some(slot);
@@ -330,8 +392,10 @@ impl ProviderHealth {
 fn apply_circuit_transitions(g: &mut Inner, name: &str, cfg: &HealthConfig) {
     match &g.circuit {
         CircuitState::Closed => {
+            // Throttles are excluded from both triggers (`hard_error_rate`,
+            // `consecutive_failures`) so a rate limit never opens the circuit.
             let should_open = g.consecutive_failures >= cfg.circuit_open_failures
-                || g.error_rate() > cfg.circuit_error_threshold;
+                || g.hard_error_rate() > cfg.circuit_error_threshold;
             if should_open {
                 g.circuit = CircuitState::Open;
                 g.circuit_opened_at = Some(Instant::now());
@@ -348,17 +412,21 @@ fn apply_circuit_transitions(g: &mut Inner, name: &str, cfg: &HealthConfig) {
             }
         }
         CircuitState::HalfOpen => {
-            // The last push_result already updated consecutive_failures.
-            // Close on success, re-open on failure.
-            let last_success = g.window.back().map(|(_, ok)| *ok).unwrap_or(false);
-            if last_success {
-                g.circuit = CircuitState::Closed;
-                g.circuit_opened_at = None;
-                info!(provider = %name, "circuit CLOSED (recovered)");
-            } else {
-                g.circuit = CircuitState::Open;
-                g.circuit_opened_at = Some(Instant::now());
-                warn!(provider = %name, "circuit OPEN (probe failed)");
+            // Close on a genuine success, reopen on a hard failure. A throttle is
+            // neutral — it neither confirms recovery nor counts as a fault — so the
+            // circuit stays half-open awaiting a decisive next outcome.
+            match g.window.back().map(|(_, s)| *s) {
+                Some(Sample::Success) => {
+                    g.circuit = CircuitState::Closed;
+                    g.circuit_opened_at = None;
+                    info!(provider = %name, "circuit CLOSED (recovered)");
+                }
+                Some(Sample::Failure) => {
+                    g.circuit = CircuitState::Open;
+                    g.circuit_opened_at = Some(Instant::now());
+                    warn!(provider = %name, "circuit OPEN (probe failed)");
+                }
+                Some(Sample::Throttle) | None => {}
             }
         }
     }
@@ -525,6 +593,19 @@ impl HealthMonitor {
             h.record(success, latency_ms, &self.cfg);
         }
     }
+
+    /// Record a rate-limit (429) outcome for a named provider — demotes its score
+    /// without opening its circuit. See [`ProviderHealth::record_throttled`].
+    pub fn record_throttled(&self, provider_name: &str, latency_ms: f64) {
+        if let Some(h) = self
+            .entries
+            .read()
+            .get(provider_name)
+            .map(|e| e.health.clone())
+        {
+            h.record_throttled(latency_ms, &self.cfg);
+        }
+    }
 }
 
 // ── Background health loop ────────────────────────────────────────────────────
@@ -578,9 +659,17 @@ async fn health_loop(
             }
             Err(e) => {
                 let ms = t0.elapsed().as_secs_f64() * 1000.0;
-                state.record(false, ms, &cfg);
-                metrics.record_probe(&provider.name, "health", "error");
-                warn!(provider = %provider.name, error = %e, "health probe failed");
+                if e.downcast_ref::<RateLimited>().is_some() {
+                    // The provider throttled even the cheap probe — a load signal,
+                    // not a fault. Demote the score but leave the circuit closed.
+                    state.record_throttled(ms, &cfg);
+                    metrics.record_probe(&provider.name, "health", "rate_limited");
+                    warn!(provider = %provider.name, "health probe rate limited (429)");
+                } else {
+                    state.record(false, ms, &cfg);
+                    metrics.record_probe(&provider.name, "health", "error");
+                    warn!(provider = %provider.name, error = %e, "health probe failed");
+                }
             }
         }
         if stop.load(Ordering::Relaxed) {
@@ -623,6 +712,20 @@ async fn probe(client: &Client, provider: &ProviderConfig) -> anyhow::Result<Pro
     })
 }
 
+/// Marker error: a probe leg received HTTP 429. Carried as a typed error (rather
+/// than flattened into a generic failure string) so the health loop can score it
+/// as a throttle — demoting the score without opening the circuit.
+#[derive(Debug)]
+struct RateLimited;
+
+impl std::fmt::Display for RateLimited {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "provider returned HTTP 429 (rate limited)")
+    }
+}
+
+impl std::error::Error for RateLimited {}
+
 /// Single `getSlot` at one commitment. Returns the slot and its round-trip ms.
 async fn get_slot(
     client: &Client,
@@ -646,6 +749,11 @@ async fn get_slot(
     let t0 = Instant::now();
     let resp = req.send().await?;
     let ms = t0.elapsed().as_secs_f64() * 1000.0;
+    // Surface a 429 as a typed error so the health loop scores it as a throttle
+    // (score demotion, no circuit trip) rather than a generic probe failure.
+    if resp.status().as_u16() == 429 {
+        return Err(anyhow::Error::new(RateLimited));
+    }
     anyhow::ensure!(resp.status().is_success(), "HTTP {}", resp.status());
     let json: Value = resp.json().await?;
     let slot = json["result"]
@@ -860,6 +968,81 @@ mod tests {
     }
 
     #[test]
+    fn throttle_demotes_score_without_opening_circuit() {
+        let cfg = HealthConfig {
+            circuit_open_failures: 3,
+            circuit_error_threshold: 0.5,
+            ..Default::default()
+        };
+        // 10 throttles — would trip both circuit triggers if counted as failures.
+        let throttled = ProviderHealth::new("throttled");
+        for _ in 0..10 {
+            throttled.record_throttled(0.0, &cfg);
+        }
+        let ts = throttled.snapshot(&tips(0), &cfg);
+        assert_eq!(
+            ts.circuit,
+            CircuitState::Closed,
+            "throttles must not open the circuit"
+        );
+        assert!(ts.is_available(), "throttled provider stays eligible");
+
+        // But the score is demoted relative to a clean provider, so best-score
+        // routing sheds traffic to peers.
+        let clean = ProviderHealth::new("clean");
+        for _ in 0..10 {
+            clean.record(true, 50.0, &cfg);
+        }
+        assert!(
+            ts.score < clean.snapshot(&tips(0), &cfg).score,
+            "throttles must demote the score (throttled={}, clean={})",
+            ts.score,
+            clean.snapshot(&tips(0), &cfg).score
+        );
+    }
+
+    #[test]
+    fn throttle_is_neutral_to_the_hard_failure_streak() {
+        // A throttle interleaved in a hard-failure run neither resets nor extends
+        // the streak: F, T, F, F must still reach circuit_open_failures = 3.
+        let ph = ProviderHealth::new("t");
+        let cfg = HealthConfig {
+            circuit_open_failures: 3,
+            circuit_error_threshold: 1.1, // disable the rate trigger
+            ..Default::default()
+        };
+        ph.record(false, 0.0, &cfg); // hard #1
+        ph.record_throttled(0.0, &cfg); // neutral
+        ph.record(false, 0.0, &cfg); // hard #2
+        assert_eq!(
+            ph.snapshot(&tips(0), &cfg).circuit,
+            CircuitState::Closed,
+            "two hard failures (throttle between) < threshold"
+        );
+        ph.record(false, 0.0, &cfg); // hard #3 → open
+        assert_eq!(ph.snapshot(&tips(0), &cfg).circuit, CircuitState::Open);
+    }
+
+    #[test]
+    fn throttle_storm_never_trips_error_rate_circuit() {
+        // Error-rate trigger at 0.5: an all-throttle window has hard_error_rate 0,
+        // so the circuit stays closed however high the throttle rate climbs.
+        let ph = ProviderHealth::new("t");
+        let cfg = HealthConfig {
+            circuit_open_failures: 100, // disable the consecutive trigger
+            circuit_error_threshold: 0.5,
+            ..Default::default()
+        };
+        for _ in 0..20 {
+            ph.record_throttled(0.0, &cfg);
+        }
+        let snap = ph.snapshot(&tips(0), &cfg);
+        assert_eq!(snap.circuit, CircuitState::Closed);
+        // Scoring error rate reflects the throttles (all non-success)...
+        assert_eq!(snap.error_rate, 1.0);
+    }
+
+    #[test]
     fn monitor_update_slot_propagates() {
         let provider = crate::config::ProviderConfig {
             name: "p".to_string(),
@@ -921,8 +1104,8 @@ mod tests {
         let mut inner = Inner::new();
         // Directly inject entries with timestamps 120 seconds in the past.
         let old = Instant::now() - Duration::from_secs(120);
-        inner.window.push_back((old, true));
-        inner.window.push_back((old, false));
+        inner.window.push_back((old, Sample::Success));
+        inner.window.push_back((old, Sample::Failure));
         assert_eq!(inner.window.len(), 2);
 
         // prune_window(60) should evict both entries (120s > 60s cutoff).
@@ -939,7 +1122,7 @@ mod tests {
         let mut inner = Inner::new();
         // Inject an entry 10 seconds old — within a 60-second window.
         let recent = Instant::now() - Duration::from_secs(10);
-        inner.window.push_back((recent, true));
+        inner.window.push_back((recent, Sample::Success));
 
         inner.prune_window(60);
         assert_eq!(inner.window.len(), 1, "recent entries must be retained");
@@ -950,15 +1133,16 @@ mod tests {
         let mut inner = Inner::new();
         let old = Instant::now() - Duration::from_secs(90);
         let recent = Instant::now() - Duration::from_secs(5);
-        inner.window.push_back((old, false));
-        inner.window.push_back((old, true));
-        inner.window.push_back((recent, true));
+        inner.window.push_back((old, Sample::Failure));
+        inner.window.push_back((old, Sample::Success));
+        inner.window.push_back((recent, Sample::Success));
 
         inner.prune_window(60);
         // Only the recent entry survives.
         assert_eq!(inner.window.len(), 1);
-        assert!(
+        assert_eq!(
             inner.window[0].1,
+            Sample::Success,
             "surviving entry should be the recent success"
         );
     }

--- a/rpc-plane-core/src/proxy.rs
+++ b/rpc-plane-core/src/proxy.rs
@@ -1,7 +1,9 @@
 use crate::config::{Config, ProviderConfig};
 use crate::health::{CircuitState, CommitmentHealth, HealthMonitor};
 use crate::metrics::Metrics;
-use crate::router::{extract_rpc_error_code, is_retryable_http, is_retryable_rpc_code, route};
+use crate::router::{
+    extract_rpc_error_code, is_client_error, is_retryable_http, is_retryable_rpc_code, route,
+};
 use crate::telemetry::{NoopReporter, Reporter, TelemetryEvent};
 use axum::{
     body::Bytes,
@@ -99,6 +101,105 @@ impl ProxyState {
     /// Cheaply snapshot the current config (clones an Arc, not the Config).
     fn current_config(&self) -> Arc<Config> {
         self.config.read().clone()
+    }
+
+    /// The cheap Arc-backed handles needed to record a request outcome, detached
+    /// from the rest of `ProxyState`. Built once per request and cloned into the
+    /// detached straggler drain, which must own its handles (`'static`).
+    fn recorder(&self) -> OutcomeRecorder {
+        OutcomeRecorder {
+            metrics: self.metrics.clone(),
+            reporter: self.reporter.clone(),
+            monitor: self.monitor.clone(),
+        }
+    }
+}
+
+/// How one forwarded leg is scored. Separates the metrics label from the health
+/// effect so a client-attributable 4xx is visible without counting against the
+/// provider, and a 429 demotes the score without opening the circuit.
+#[derive(Clone, Copy)]
+enum Outcome {
+    /// A real success — 2xx with no JSON-RPC `error` body. Feeds health as a
+    /// success and is the only outcome that ends a broadcast race.
+    Ok,
+    /// Provider-attributable failure — a 5xx, an auth 4xx, a 2xx carrying an
+    /// error body, an upstream `Err`, or a retryable JSON-RPC error. Feeds health
+    /// as a hard failure.
+    ProviderError,
+    /// HTTP 429 — a load signal, not a fault. Fails over like a 5xx, but demotes
+    /// the provider's score without opening its circuit (see [`HealthMonitor`]).
+    RateLimited,
+    /// Client-attributable 4xx — recorded for visibility, never fed to health.
+    ClientError,
+}
+
+impl Outcome {
+    /// Classify from the HTTP status alone (sequential path — the status has
+    /// already been separated from any 2xx error body by earlier branches).
+    fn from_status(status: u16) -> Self {
+        if (200..300).contains(&status) {
+            Outcome::Ok
+        } else if status == 429 {
+            Outcome::RateLimited
+        } else if is_client_error(status) {
+            Outcome::ClientError
+        } else {
+            Outcome::ProviderError
+        }
+    }
+
+    /// Classify a broadcast leg, which is a success only on a 2xx with no
+    /// JSON-RPC error body ([`leg_succeeded`]); a 2xx carrying an error body is a
+    /// provider failure (a preflight -32002), not a success.
+    fn from_leg(status: u16, bytes: &Bytes) -> Self {
+        if leg_succeeded(status, bytes) {
+            Outcome::Ok
+        } else if status == 429 {
+            Outcome::RateLimited
+        } else if is_client_error(status) {
+            Outcome::ClientError
+        } else {
+            Outcome::ProviderError
+        }
+    }
+
+    /// The `status` label written to metrics/telemetry.
+    fn label(self) -> &'static str {
+        match self {
+            Outcome::Ok => "ok",
+            Outcome::ProviderError => "error",
+            Outcome::RateLimited => "rate_limited",
+            Outcome::ClientError => "client_error",
+        }
+    }
+}
+
+/// Bundles the cheap Arc-backed handles a request outcome touches so both the
+/// hot path and the detached straggler drain record through one place.
+#[derive(Clone)]
+struct OutcomeRecorder {
+    metrics: Metrics,
+    reporter: Arc<dyn Reporter>,
+    monitor: HealthMonitor,
+}
+
+impl OutcomeRecorder {
+    /// Record one forwarded leg across metrics, telemetry, and provider health.
+    /// The health effect is per-outcome: success/failure feed the circuit, a 429
+    /// demotes the score only, and a client-attributable 4xx is health-neutral.
+    fn record(&self, method: &str, name: &str, outcome: Outcome, latency_ms: f64, count: u64) {
+        let label = outcome.label();
+        self.metrics
+            .record_request(method, name, label, latency_ms, count);
+        self.reporter
+            .record_request(method, name, label, latency_ms, count);
+        match outcome {
+            Outcome::Ok => self.monitor.record(name, true, latency_ms),
+            Outcome::ProviderError => self.monitor.record(name, false, latency_ms),
+            Outcome::RateLimited => self.monitor.record_throttled(name, latency_ms),
+            Outcome::ClientError => {}
+        }
     }
 }
 
@@ -251,6 +352,7 @@ async fn sequential(
     } = ctx;
     let max_attempts = (config.routing.max_retries + 1).min(providers.len());
     let mut prev_failed: Option<(Arc<str>, &'static str)> = None; // (name, reason)
+    let recorder = state.recorder();
 
     for (attempt, name) in providers.iter().enumerate().take(max_attempts) {
         if attempt > 0 {
@@ -281,27 +383,47 @@ async fn sequential(
 
         match result {
             Ok((status, bytes)) => {
-                // Non-2xx that wasn't retryable (retryable HTTP already became an
-                // Err above): a permanent provider error such as a revoked-key 401.
-                // Record it as an error so health scoring reflects real traffic, and
-                // pass the status through to the client instead of replying 200.
-                // Do not fail over — it is non-retryable by construction.
-                if !(200..300).contains(&status) {
+                // Retryable HTTP (429 or 5xx): fail over to the next provider. A
+                // 5xx is a provider fault (`ProviderError`); a 429 is a load signal
+                // (`RateLimited`) that demotes the provider's score so traffic
+                // sheds to peers but leaves its circuit closed. On exhaustion the
+                // loop falls through to the generic "all providers failed" 502.
+                if is_retryable_http(status) {
+                    let outcome = Outcome::from_status(status);
                     warn!(
                         request_id = %request_id,
                         provider = %name,
                         method,
                         attempt,
                         status,
+                        outcome = outcome.label(),
+                        "retryable upstream status, trying next provider"
+                    );
+                    recorder.record(method, name, outcome, latency_ms, count);
+                    prev_failed = Some((name.clone(), "retryable_http"));
+                    continue;
+                }
+
+                // Non-2xx that wasn't retryable. Pass the status through to the
+                // client instead of replying 200, and do not fail over — it is
+                // non-retryable by construction. A client-attributable 4xx
+                // (malformed body, unknown route, oversized payload …) is the
+                // caller's fault, so it is recorded as `client_error` and left out
+                // of provider health; otherwise a buggy client loop could open
+                // every circuit. Auth failures (401/403) still score as errors —
+                // a revoked key makes the provider genuinely unusable.
+                if !(200..300).contains(&status) {
+                    let outcome = Outcome::from_status(status);
+                    warn!(
+                        request_id = %request_id,
+                        provider = %name,
+                        method,
+                        attempt,
+                        status,
+                        outcome = outcome.label(),
                         "upstream non-2xx, passing status through"
                     );
-                    state
-                        .metrics
-                        .record_request(method, name, "error", latency_ms, count);
-                    state
-                        .reporter
-                        .record_request(method, name, "error", latency_ms, count);
-                    state.monitor.record(name, false, latency_ms);
+                    recorder.record(method, name, outcome, latency_ms, count);
                     return (
                         StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
                         [("content-type", "application/json")],
@@ -320,13 +442,7 @@ async fn sequential(
                             attempt,
                             "retryable RPC error, trying next provider"
                         );
-                        state
-                            .metrics
-                            .record_request(method, name, "error", latency_ms, count);
-                        state
-                            .reporter
-                            .record_request(method, name, "error", latency_ms, count);
-                        state.monitor.record(name, false, latency_ms);
+                        recorder.record(method, name, Outcome::ProviderError, latency_ms, count);
                         prev_failed = Some((name.clone(), "retryable_rpc_error"));
                         continue;
                     }
@@ -339,13 +455,7 @@ async fn sequential(
                     latency_ms = format!("{latency_ms:.1}"),
                     "request ok"
                 );
-                state
-                    .metrics
-                    .record_request(method, name, "ok", latency_ms, count);
-                state
-                    .reporter
-                    .record_request(method, name, "ok", latency_ms, count);
-                state.monitor.record(name, true, latency_ms);
+                recorder.record(method, name, Outcome::Ok, latency_ms, count);
                 return (
                     StatusCode::OK,
                     [("content-type", "application/json")],
@@ -362,13 +472,7 @@ async fn sequential(
                     error = %e,
                     "provider error, trying next"
                 );
-                state
-                    .metrics
-                    .record_request(method, name, "error", latency_ms, count);
-                state
-                    .reporter
-                    .record_request(method, name, "error", latency_ms, count);
-                state.monitor.record(name, false, latency_ms);
+                recorder.record(method, name, Outcome::ProviderError, latency_ms, count);
                 prev_failed = Some((name.clone(), "provider_error"));
             }
         }
@@ -441,13 +545,14 @@ async fn broadcast(
     // succeeds, the client gets a real upstream error (a deterministic -32602/-32002
     // it can act on) instead of a generic "all providers failed".
     let mut best_error: Option<(u16, Bytes, u8)> = None; // (status, body, rank)
+    let recorder = state.recorder();
 
     while let Some(res) = set.join_next().await {
         match res {
             Ok((name, Ok((status, bytes)), latency_ms)) => {
-                let success = leg_succeeded(status, &bytes);
-                record_broadcast_outcome(state, method, &name, success, latency_ms, count);
-                if success {
+                let outcome = Outcome::from_leg(status, &bytes);
+                recorder.record(method, &name, outcome, latency_ms, count);
+                if matches!(outcome, Outcome::Ok) {
                     info!(
                         request_id = %request_id,
                         provider = %name,
@@ -455,7 +560,7 @@ async fn broadcast(
                         latency_ms = format!("{latency_ms:.1}"),
                         "broadcast first success"
                     );
-                    spawn_straggler_drain(state, method, request_id, count, set);
+                    spawn_straggler_drain(recorder, method, request_id, count, set);
                     return (
                         StatusCode::OK,
                         [("content-type", "application/json")],
@@ -464,7 +569,7 @@ async fn broadcast(
                         .into_response();
                 }
                 let rpc_code = extract_rpc_error_code(&bytes);
-                warn!(request_id = %request_id, provider = %name, method, status, code = ?rpc_code, "broadcast leg failed");
+                warn!(request_id = %request_id, provider = %name, method, status, code = ?rpc_code, outcome = outcome.label(), "broadcast leg failed");
                 let rank = broadcast_error_rank(status, rpc_code);
                 if best_error.as_ref().is_none_or(|(_, _, best)| rank > *best) {
                     best_error = Some((status, bytes, rank));
@@ -472,7 +577,7 @@ async fn broadcast(
             }
             Ok((name, Err(e), latency_ms)) => {
                 warn!(request_id = %request_id, provider = %name, method, error = %e, "broadcast provider failed");
-                record_broadcast_outcome(state, method, &name, false, latency_ms, count);
+                recorder.record(method, &name, Outcome::ProviderError, latency_ms, count);
             }
             Err(e) => {
                 warn!(request_id = %request_id, error = %e, "broadcast task panicked");
@@ -495,25 +600,6 @@ async fn broadcast(
     }
     error!(%request_id, method, "all broadcast providers failed");
     json_error_response(StatusCode::BAD_GATEWAY, -32603, "all providers failed")
-}
-
-/// Record one broadcast provider outcome across metrics, telemetry, and health.
-fn record_broadcast_outcome(
-    state: &ProxyState,
-    method: &str,
-    name: &str,
-    success: bool,
-    latency_ms: f64,
-    count: u64,
-) {
-    let status = if success { "ok" } else { "error" };
-    state
-        .metrics
-        .record_request(method, name, status, latency_ms, count);
-    state
-        .reporter
-        .record_request(method, name, status, latency_ms, count);
-    state.monitor.record(name, success, latency_ms);
 }
 
 /// A broadcast leg counts as a success only on HTTP 2xx *and* a body with no
@@ -539,38 +625,32 @@ fn broadcast_error_rank(status: u16, rpc_code: Option<i64>) -> u8 {
 
 /// Drain the remaining in-flight broadcast tasks in the background after the
 /// client has already been answered, so late providers still feed metrics and
-/// health. Clones only the cheap Arc-backed handles off `ProxyState`; the
-/// JoinSet is moved in and owns everything it needs ('static).
+/// health. The `recorder` owns the cheap Arc-backed handles it needs; the
+/// JoinSet is moved in and owns everything else ('static).
 fn spawn_straggler_drain(
-    state: &ProxyState,
+    recorder: OutcomeRecorder,
     method: &str,
     request_id: Uuid,
     count: u64,
     mut set: JoinSet<ForwardOutcome>,
 ) {
-    let metrics = state.metrics.clone();
-    let reporter = state.reporter.clone();
-    let monitor = state.monitor.clone();
     let method = method.to_string();
     tokio::spawn(async move {
         while let Some(res) = set.join_next().await {
-            let (name, success, latency_ms) = match res {
+            let (name, outcome, latency_ms) = match res {
                 Ok((name, Ok((status, bytes)), latency_ms)) => {
-                    (name, leg_succeeded(status, &bytes), latency_ms)
+                    (name, Outcome::from_leg(status, &bytes), latency_ms)
                 }
                 Ok((name, Err(e), latency_ms)) => {
                     warn!(request_id = %request_id, provider = %name, error = %e, "broadcast straggler failed");
-                    (name, false, latency_ms)
+                    (name, Outcome::ProviderError, latency_ms)
                 }
                 Err(e) => {
                     warn!(request_id = %request_id, error = %e, "broadcast straggler task panicked");
                     continue;
                 }
             };
-            let status = if success { "ok" } else { "error" };
-            metrics.record_request(&method, &name, status, latency_ms, count);
-            reporter.record_request(&method, &name, status, latency_ms, count);
-            monitor.record(&name, success, latency_ms);
+            recorder.record(&method, &name, outcome, latency_ms, count);
         }
     });
 }
@@ -601,13 +681,11 @@ async fn forward(
     let resp = builder.body(body.clone()).send().await?;
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await?;
-    // Retryable statuses (429/5xx) become an Err so the caller fails over to the
-    // next provider. Every other status — including non-retryable 4xx like a
-    // revoked-key 401 — is returned with its code so the caller can pass it
-    // through to the client and score it correctly, instead of masking it as 200.
-    if is_retryable_http(status) {
-        anyhow::bail!("provider returned HTTP {status}");
-    }
+    // Return the status and body for every HTTP response and let the caller
+    // decide: retryable statuses (429/5xx) fail over to the next provider,
+    // non-retryable 4xx pass through. Only a transport-level error (the `?`s
+    // above) is an `Err`. This keeps the 429 → rate-limit classification intact
+    // on both the sequential and broadcast paths.
     Ok((status, bytes))
 }
 

--- a/rpc-plane-core/src/router.rs
+++ b/rpc-plane-core/src/router.rs
@@ -15,10 +15,9 @@ pub enum MethodClass {
 
 /// Classify a method as a read or write given the configured write-method list.
 ///
-/// The list is operator-controlled (`routing.write_methods`) and defaults to
-/// `["sendTransaction"]` only — `simulateTransaction` is read-only and routes
-/// like a read unless explicitly added. It can be overridden to add or remove
-/// methods.
+/// The list is operator-controlled (`routing.write_methods`); it defaults to
+/// `sendTransaction` + `simulateTransaction` so simulations route on the fast
+/// write path, but it can be overridden to add or remove methods.
 pub fn classify(method: &str, write_methods: &[String]) -> MethodClass {
     if write_methods.iter().any(|m| m == method) {
         MethodClass::Write
@@ -32,6 +31,24 @@ pub fn classify(method: &str, write_methods: &[String]) -> MethodClass {
 /// HTTP-level errors worth retrying on the next provider.
 pub fn is_retryable_http(status: u16) -> bool {
     matches!(status, 429 | 500 | 502 | 503 | 504)
+}
+
+/// Non-retryable 4xx statuses attributable to the *client's* request rather than
+/// the provider: a malformed body (400), an unknown route (404), a wrong HTTP
+/// method (405), an oversized body (413), an unsupported media type (415), or an
+/// unprocessable request (422).
+///
+/// These are passed through to the caller but must **not** count against provider
+/// health. A buggy client loop hammering a request that 400s would otherwise
+/// drive every provider's error window up and serially open their circuits —
+/// painting the whole fleet as down when the fault is the caller's own code.
+///
+/// Auth failures (401/403) are deliberately excluded: a revoked or wrong key
+/// makes the provider genuinely unusable, so it should score as an error and its
+/// circuit should open. `429` is not here either — it is a retryable status
+/// (`is_retryable_http`) that fails over to the next provider.
+pub fn is_client_error(status: u16) -> bool {
+    matches!(status, 400 | 404 | 405 | 413 | 415 | 422)
 }
 
 /// JSON-RPC error codes that may succeed on a different provider.
@@ -418,6 +435,27 @@ mod tests {
             assert!(
                 !is_retryable_http(code),
                 "expected {code} to be non-retryable"
+            );
+        }
+    }
+
+    #[test]
+    fn client_attributable_4xx_recognised() {
+        for code in [400u16, 404, 405, 413, 415, 422] {
+            assert!(
+                is_client_error(code),
+                "expected {code} to be client-attributable"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_and_auth_statuses_are_not_client_errors() {
+        // Auth (401/403) → provider unusable; 429/5xx → retryable; 2xx → success.
+        for code in [200u16, 401, 403, 429, 500, 502, 503, 504] {
+            assert!(
+                !is_client_error(code),
+                "expected {code} to NOT be client-attributable"
             );
         }
     }

--- a/rpc-plane-core/tests/integration.rs
+++ b/rpc-plane-core/tests/integration.rs
@@ -6,6 +6,7 @@
 use axum::{
     body::Body,
     http::{Method, Request, StatusCode},
+    response::IntoResponse,
     routing::{get, post},
     Router,
 };
@@ -854,5 +855,120 @@ async fn upstream_4xx_status_passed_through_not_200() {
         status,
         StatusCode::UNAUTHORIZED,
         "upstream 401 must pass through, not be masked as 200"
+    );
+}
+
+const GET_BALANCE: &str = r#"{"jsonrpc":"2.0","id":1,"method":"getBalance","params":["addr"]}"#;
+
+/// A mock that answers `getSlot` health probes normally (so probe failures don't
+/// muddy the health signal) but returns `status` for the real `getBalance` call.
+async fn start_status_on_get_balance(status: StatusCode) -> (String, tokio::task::AbortHandle) {
+    let router = Router::new().route(
+        "/",
+        post(move |body: axum::body::Bytes| async move {
+            if std::str::from_utf8(&body).is_ok_and(|s| s.contains("getBalance")) {
+                (
+                    status,
+                    r#"{"jsonrpc":"2.0","error":{"code":0,"message":"x"},"id":1}"#,
+                )
+                    .into_response()
+            } else {
+                slot_response(1).into_response()
+            }
+        }),
+    );
+    start_mock(router).await
+}
+
+/// CONTRACT: a client-attributable 4xx (400) is passed through to the caller but
+/// must NOT count against provider health — a buggy client loop that keeps
+/// tripping a 400 cannot open the circuit and paint the provider as down.
+#[tokio::test]
+async fn client_4xx_passed_through_without_touching_health() {
+    let (url, _abort) = start_status_on_get_balance(StatusCode::BAD_REQUEST).await;
+
+    // circuit_open_failures = 2: two *counted* failures would open the circuit.
+    let cfg = test_config(&[("a", &url)], RoutingStrategy::FailoverOrdered, 0, 2);
+    let state = ProxyState::new(cfg);
+    let router = build_router(state.clone());
+
+    for _ in 0..5 {
+        let (status, _body) = proxy_request(router.clone(), GET_BALANCE).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "400 must pass through");
+    }
+
+    let snap = state.monitor.snapshots().pop().unwrap();
+    assert_eq!(
+        snap.circuit,
+        rpc_plane_core::health::CircuitState::Closed,
+        "client 4xx must not open the circuit"
+    );
+    assert_eq!(snap.error_rate, 0.0, "client 4xx must not raise error rate");
+}
+
+/// CONTRACT: an auth 4xx (401) is a genuine provider problem (revoked key) — it
+/// must count against health and, with enough failures, open the circuit.
+#[tokio::test]
+async fn auth_4xx_counts_against_health_and_opens_circuit() {
+    let (url, _abort) = start_status_on_get_balance(StatusCode::UNAUTHORIZED).await;
+
+    let cfg = test_config(&[("a", &url)], RoutingStrategy::FailoverOrdered, 0, 2);
+    let state = ProxyState::new(cfg);
+    let router = build_router(state.clone());
+
+    for _ in 0..3 {
+        let (status, _body) = proxy_request(router.clone(), GET_BALANCE).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "401 must pass through");
+    }
+
+    let snap = state.monitor.snapshots().pop().unwrap();
+    assert_eq!(
+        snap.circuit,
+        rpc_plane_core::health::CircuitState::Open,
+        "auth 4xx must open the circuit"
+    );
+}
+
+/// CONTRACT (429 handling): a rate-limited provider fails over *and* is demoted
+/// so traffic sheds to peers, but its circuit stays CLOSED — a 429 is a load
+/// signal, not a fault. Provider A 429s every real call (its probes still 200);
+/// B serves. Even with `circuit_open_failures = 2`, A must never open.
+#[tokio::test]
+async fn rate_limited_provider_demoted_but_circuit_stays_closed() {
+    let (url_a, _abort_a) = start_status_on_get_balance(StatusCode::TOO_MANY_REQUESTS).await;
+    let mock_b = Router::new().route("/", post(|| async { slot_response(7) }));
+    let (url_b, _abort_b) = start_mock(mock_b).await;
+
+    // max_retries=1 so A→B failover happens; circuit_open_failures=2 would open A
+    // fast if 429s were counted as failures.
+    let cfg = test_config(
+        &[("a", &url_a), ("b", &url_b)],
+        RoutingStrategy::FailoverOrdered,
+        1,
+        2,
+    );
+    let state = ProxyState::new(cfg);
+    let router = build_router(state.clone());
+
+    for _ in 0..8 {
+        let (status, body) = proxy_request(router.clone(), GET_BALANCE).await;
+        assert_eq!(status, StatusCode::OK, "B must serve after A is throttled");
+        assert_eq!(body["result"].as_u64(), Some(7));
+    }
+
+    let snaps = state.monitor.snapshots();
+    let a = snaps.iter().find(|s| s.name.as_ref() == "a").unwrap();
+    let b = snaps.iter().find(|s| s.name.as_ref() == "b").unwrap();
+    assert_eq!(
+        a.circuit,
+        rpc_plane_core::health::CircuitState::Closed,
+        "429 must not open the circuit"
+    );
+    assert!(a.is_available(), "throttled provider stays eligible");
+    assert!(
+        a.score < b.score,
+        "throttled provider must be demoted (a={}, b={})",
+        a.score,
+        b.score
     );
 }


### PR DESCRIPTION
## Summary

Refines how upstream errors are attributed to provider health, so that failures the provider isn't responsible for can't degrade or exclude it.

**Client-attributable 4xx** (`400/404/405/413/415/422`) are passed through to the caller but no longer count against provider health. Previously a buggy client loop tripping a `400` would drive every provider's error window up and serially open their circuits — painting the whole fleet as down when the fault is the caller's own code. Auth failures (`401/403`) still count, since a revoked or wrong key makes the provider genuinely unusable.

**HTTP 429** is now treated as a load signal, not a fault. It still fails over to the next provider and **demotes** the throttled provider's score (so best-score/weighted routing sheds traffic to peers with headroom), but it is **excluded from the circuit breaker**. A rate-limited-but-healthy provider stays eligible and reabsorbs load the instant the burst passes, instead of being excluded for the full cooldown and cascading its traffic onto the survivors — precisely the failover moment when you can least afford it.

## How

- **Three-state health window** (`success` / `failure` / `throttle`). The scoring error rate counts throttles (demotes the score); the circuit-breaker error rate counts only hard failures. A throttle is neutral to the consecutive-failure count, the latency EMA, and half-open recovery. New `record_throttled()`; a probe that is itself `429`'d is throttle-scored too.
- **Unified leg classification** in `proxy.rs`: each forwarded leg maps to `ok`/`error`/`rate_limited`/`client_error` via one `Outcome` type recorded through a single `OutcomeRecorder`, composing with the existing broadcast success/error-rank logic. `forward()` returns the status for retryable responses so the caller can distinguish `429` from `5xx`.
- **New status label values** `rate_limited` and `client_error` on `rpc_plane_requests_total` (and `rate_limited` on the probe counter), kept distinct from `error` so a throttle or a caller bug isn't read as a provider fault or counted into provider error-rate panels.
- Fixes a stale `classify` doc comment (`write_methods` defaults to `sendTransaction` only).

## Behavior notes

- Failover semantics are unchanged: `429`/`5xx` fail over; on exhaustion the sequential path still returns the generic `502`. The broadcast 2xx-with-error-body fix and its best-error selection are preserved (their contract tests pass unchanged).
- Docs for the new status values and health semantics are updated in the docs repo.

Tests: 95 lib + 23 integration pass; `cargo fmt`/`clippy --all-targets` clean. New coverage: client 4xx does not open the circuit while auth 4xx does; a rate-limited provider stays closed-circuit but demoted; three health-window unit tests.