### PR TITLE
Per-provider max_rps rate limiting

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -51,9 +51,13 @@ http3  = true   # opt-in HTTP/3 (QUIC). No HTTP/2 fallback — only for endpoint
                 # enable HTTP/3". Leave it off (the default) unless you're on a cold/lossy path.
 
 [[providers]]
-name   = "quicknode"
-url    = "https://your-endpoint.quiknode.pro/${QUICKNODE_API_KEY}"
-weight = 1
+name    = "quicknode"
+url     = "https://your-endpoint.quiknode.pro/${QUICKNODE_API_KEY}"
+weight  = 1
+# max_rps = 50   # optional per-provider rate cap (requests/sec). Once a provider is
+                 # dispatching at its cap it's treated as unavailable so load sheds to
+                 # peers with headroom. Load-shedding hint, not a hard throttle: with no
+                 # other provider free the request is still forwarded. Omit for no limit.
 
 [[providers]]
 name   = "triton"

--- a/examples/dedicated-with-metered-backup.toml
+++ b/examples/dedicated-with-metered-backup.toml
@@ -43,3 +43,7 @@ url  = "${DEDICATED_URL}"
 [[providers]]
 name = "quicknode-backup"
 url  = "https://your-endpoint.quiknode.pro/${QUICKNODE_API_KEY}"
+# max_rps = 100   # optional cost guardrail: cap how fast the metered backup can be
+                  # billed while the primary is down. At the cap it's treated as
+                  # unavailable — but as the only provider left it still serves
+                  # (load-shedding hint, not a hard throttle).

--- a/examples/free-tier.toml
+++ b/examples/free-tier.toml
@@ -1,16 +1,20 @@
 # Free-tier maxxing
 #
-# Spreads load across five free or no-cost endpoints so no single provider
-# sees enough traffic to hit its rate limit.
+# Spreads load across four free or no-cost endpoints so no single provider
+# sees enough traffic to hit its rate limit. The optional `max_rps` cap on each
+# provider makes that explicit: once a provider is dispatching at its plan's
+# per-second limit it's treated as unavailable and load sheds to the others, so
+# you stop hitting a free key's 429s before they happen. Set each cap to the
+# limit your plan actually documents — the values below are illustrative.
 #
-# Two providers need no sign-up at all:
+# One provider needs no sign-up at all:
 #   - api.mainnet-beta.solana.com  (Solana Foundation public RPC)
-#   - rpc.ankr.com/solana          (Ankr public RPC)
 #
-# The remaining three require a free account:
-#   - Helius   https://helius.dev       (Developer plan)
-#   - QuickNode https://quicknode.com   (Free starter endpoint)
-#   - Alchemy  https://alchemy.com      (Free tier)
+# The other three require a free account:
+#   - Helius    https://helius.dev       (Developer plan)
+#   - QuickNode https://quicknode.com    (Free endpoint — note: the free tier
+#                                         only lasts ~1 month, then it's paid)
+#   - Alchemy   https://alchemy.com       (Free tier)
 #
 # Usage:
 #   export HELIUS_API_KEY=...
@@ -31,35 +35,34 @@ circuit_cooldown_secs   = 2     # RPS windows reset per-second; recover fast
 
 [routing]
 strategy    = "weighted_random"  # spread load evenly — avoid hammering one key
-max_retries = 4                  # try all five before giving up
+max_retries = 3                  # try all four before giving up
 
 # ── No sign-up required ────────────────────────────────────────────────────────
 
 [[providers]]
-name   = "solana-foundation"
-url    = "https://api.mainnet-beta.solana.com"
-weight = 1
-
-[[providers]]
-name   = "ankr"
-url    = "https://rpc.ankr.com/solana"
-weight = 1
+name    = "solana-foundation"
+url     = "https://api.mainnet-beta.solana.com"
+weight  = 1
+max_rps = 10   # illustrative — set to your plan's documented per-second limit
 
 # ── Free-tier accounts ─────────────────────────────────────────────────────────
 
 [[providers]]
-name   = "helius"
-url    = "https://mainnet.helius-rpc.com/?api-key=${HELIUS_API_KEY}"
-weight = 1
+name    = "helius"
+url     = "https://mainnet.helius-rpc.com/?api-key=${HELIUS_API_KEY}"
+weight  = 1
+max_rps = 10
 # http3 = true   # opt-in QUIC. Can help on a lossy home/last-mile link, but there's no
                  # HTTP/2 fallback — only enable if your endpoint serves QUIC. See docs.
 
 [[providers]]
-name   = "quicknode"
-url    = "https://your-endpoint.quiknode.pro/${QUICKNODE_API_KEY}"
-weight = 1
+name    = "quicknode"
+url     = "https://your-endpoint.quiknode.pro/${QUICKNODE_API_KEY}"
+weight  = 1
+max_rps = 15   # heads up: QuickNode's free endpoint only lasts ~1 month, then it's paid
 
 [[providers]]
-name   = "alchemy"
-url    = "https://solana-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-weight = 1
+name    = "alchemy"
+url     = "https://solana-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+weight  = 1
+max_rps = 15

--- a/rpc-plane-core/benches/proxy_bench.rs
+++ b/rpc-plane-core/benches/proxy_bench.rs
@@ -22,6 +22,7 @@ fn snap(name: &str, score: f64) -> HealthSnapshot {
         processed: CommitmentHealth::default(),
         confirmed: CommitmentHealth::default(),
         finalized: CommitmentHealth::default(),
+        rate_limited: false,
     }
 }
 
@@ -32,6 +33,7 @@ fn prov(name: &str) -> ProviderConfig {
         weight: 1,
         http3: false,
         methods: None,
+        max_rps: None,
     }
 }
 

--- a/rpc-plane-core/src/config.rs
+++ b/rpc-plane-core/src/config.rs
@@ -58,6 +58,11 @@ impl Config {
                     p.name
                 );
             }
+            anyhow::ensure!(
+                p.max_rps.is_none_or(|r| r >= 1),
+                "provider '{}' has max_rps = 0; use a positive value or omit the key for no limit",
+                p.name
+            );
         }
         anyhow::ensure!(
             self.routing
@@ -337,6 +342,16 @@ pub struct ProviderConfig {
     /// list; otherwise health is driven by real request outcomes.
     #[serde(default)]
     pub methods: Option<Vec<String>>,
+    /// Optional per-provider rate cap in requests per second. When set, a token
+    /// bucket (capacity = one second of tokens, refilled at `max_rps`/s) sheds
+    /// load once the provider is dispatching at its cap: an empty bucket makes
+    /// the provider *unavailable* for routing so traffic shifts to peers with
+    /// headroom, exactly like a demoted health score. It is a load-shedding cap,
+    /// not a hard throttle — if every eligible provider is at capacity the proxy
+    /// still forwards (degraded) rather than failing the request. Unset (the
+    /// default) means unlimited, with zero per-request overhead.
+    #[serde(default)]
+    pub max_rps: Option<u32>,
 }
 
 impl ProviderConfig {
@@ -516,6 +531,39 @@ methods = ["sendTransaction"]
         assert!(general.supports("getSlot"));
         assert!(submit.supports("sendTransaction"));
         assert!(!submit.supports("getSlot"));
+    }
+
+    #[test]
+    fn parses_provider_max_rps() {
+        let f = write_config(
+            r#"
+[[providers]]
+name = "capped"
+url = "http://localhost:8899"
+max_rps = 50
+
+[[providers]]
+name = "uncapped"
+url = "http://localhost:9000"
+"#,
+        );
+        let cfg = Config::load(f.path()).unwrap();
+        assert_eq!(cfg.providers[0].max_rps, Some(50));
+        assert_eq!(cfg.providers[1].max_rps, None);
+    }
+
+    #[test]
+    fn rejects_zero_max_rps() {
+        let f = write_config(
+            r#"
+[[providers]]
+name = "capped"
+url = "http://localhost:8899"
+max_rps = 0
+"#,
+        );
+        let err = Config::load(f.path()).unwrap_err().to_string();
+        assert!(err.contains("max_rps = 0"), "got: {err}");
     }
 
     #[test]

--- a/rpc-plane-core/src/health.rs
+++ b/rpc-plane-core/src/health.rs
@@ -1,7 +1,7 @@
 use crate::config::{HealthConfig, ProviderConfig};
 use crate::metrics::Metrics;
 use crate::proxy::Clients;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use reqwest::Client;
 use serde_json::Value;
 use std::collections::{HashMap, VecDeque};
@@ -31,6 +31,100 @@ enum Sample {
     Success,
     Failure,
     Throttle,
+}
+
+// ── Per-provider rate limiting ────────────────────────────────────────────────
+
+/// A simple token bucket. The capacity is one second's worth of tokens (`rate`),
+/// so a provider can burst up to `max_rps` and then sustains `max_rps`/s as the
+/// bucket refills continuously. Fractional tokens keep the refill smooth between
+/// sub-millisecond dispatches. All state is behind a [`RateLimiter`] mutex.
+#[derive(Debug)]
+struct TokenBucket {
+    /// Tokens available right now (fractional).
+    tokens: f64,
+    /// Ceiling the bucket refills to — one second of `rate` (the burst size).
+    capacity: f64,
+    /// Refill rate in tokens/second (= configured `max_rps`).
+    rate: f64,
+    /// When the bucket was last refilled.
+    last: Instant,
+}
+
+impl TokenBucket {
+    fn new(max_rps: u32) -> Self {
+        let cap = f64::from(max_rps);
+        // Start full so a freshly (re)configured provider can serve immediately.
+        Self {
+            tokens: cap,
+            capacity: cap,
+            rate: cap,
+            last: Instant::now(),
+        }
+    }
+
+    /// Add the tokens accrued since the last refill, capped at `capacity`.
+    fn refill(&mut self, now: Instant) {
+        let elapsed = now.saturating_duration_since(self.last).as_secs_f64();
+        if elapsed > 0.0 {
+            self.tokens = (self.tokens + elapsed * self.rate).min(self.capacity);
+            self.last = now;
+        }
+    }
+
+    /// Spend one token if available. Returns whether a token was taken.
+    fn try_acquire(&mut self) -> bool {
+        self.refill(Instant::now());
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether a token is available, *without* spending it — the routing peek.
+    fn has_capacity(&mut self) -> bool {
+        self.refill(Instant::now());
+        self.tokens >= 1.0
+    }
+
+    /// Reconfigure the rate/capacity in place (hot reload), keeping the current
+    /// token level (clamped to the new ceiling) so a rate tweak doesn't reset the
+    /// bucket or hand out a fresh burst.
+    fn reconfigure(&mut self, max_rps: u32) {
+        self.refill(Instant::now());
+        let cap = f64::from(max_rps);
+        self.capacity = cap;
+        self.rate = cap;
+        self.tokens = self.tokens.min(cap);
+    }
+}
+
+/// Per-provider rate limiter guarding a [`TokenBucket`]. Present only for
+/// providers with a `max_rps` cap configured; unlimited providers hold `None`
+/// and never touch this lock on the hot path.
+#[derive(Debug)]
+pub struct RateLimiter(Mutex<TokenBucket>);
+
+impl RateLimiter {
+    fn new(max_rps: u32) -> Arc<Self> {
+        Arc::new(Self(Mutex::new(TokenBucket::new(max_rps))))
+    }
+
+    /// Spend one token — called once per dispatch to a capped provider.
+    fn try_acquire(&self) -> bool {
+        self.0.lock().try_acquire()
+    }
+
+    /// Peek at remaining capacity for a routing snapshot (no token spent).
+    fn has_capacity(&self) -> bool {
+        self.0.lock().has_capacity()
+    }
+
+    fn reconfigure(&self, max_rps: u32) {
+        self.0.lock().reconfigure(max_rps);
+    }
 }
 
 // ── Commitment isolation ─────────────────────────────────────────────────────
@@ -151,11 +245,20 @@ pub struct HealthSnapshot {
     pub processed: CommitmentHealth,
     pub confirmed: CommitmentHealth,
     pub finalized: CommitmentHealth,
+    /// True when the provider's per-provider `max_rps` token bucket is empty —
+    /// it is at its configured cap and should shed to peers. Always false for a
+    /// provider with no cap. Set by [`HealthMonitor::snapshots`], which peeks the
+    /// bucket without spending a token.
+    pub rate_limited: bool,
 }
 
 impl HealthSnapshot {
+    /// Eligible for normal routing. An open circuit (broken) or an empty rate
+    /// bucket (at its configured cap) both make a provider unavailable so the
+    /// router shifts load to peers; the all-unavailable fallback in `route` still
+    /// reaches these as a last resort.
     pub fn is_available(&self) -> bool {
-        self.circuit != CircuitState::Open
+        self.circuit != CircuitState::Open && !self.rate_limited
     }
 }
 
@@ -380,6 +483,10 @@ impl ProviderHealth {
             processed,
             confirmed,
             finalized,
+            // The bucket lives on the monitor's `ProviderEntry`, not here;
+            // `HealthMonitor::snapshots` overlays the peek. A bare per-provider
+            // snapshot (unit tests) has no cap and so is never rate-limited.
+            rate_limited: false,
         }
     }
 
@@ -463,8 +570,16 @@ fn apply_circuit_transitions(g: &mut Inner, name: &str, cfg: &HealthConfig) {
 
 struct ProviderEntry {
     health: Arc<ProviderHealth>,
+    /// Per-provider rate limiter, or `None` when the provider has no `max_rps`
+    /// cap (unlimited — the hot path never locks a bucket).
+    limiter: Option<Arc<RateLimiter>>,
     /// Set to true to signal the background loops for this provider to exit.
     stop: Arc<AtomicBool>,
+}
+
+/// Build a provider's rate limiter from its optional `max_rps` cap.
+fn build_limiter(max_rps: Option<u32>) -> Option<Arc<RateLimiter>> {
+    max_rps.map(RateLimiter::new)
 }
 
 /// Metric `provider` label used for the external reference probe. Distinguished
@@ -496,6 +611,7 @@ impl HealthMonitor {
                     p.name.clone(),
                     ProviderEntry {
                         health: ProviderHealth::new(p.name.as_str()),
+                        limiter: build_limiter(p.max_rps),
                         stop: Arc::new(AtomicBool::new(false)),
                     },
                 )
@@ -555,6 +671,7 @@ impl HealthMonitor {
     pub fn add_provider(&self, client: Arc<Client>, provider: ProviderConfig) {
         let stop = Arc::new(AtomicBool::new(false));
         let health = ProviderHealth::new(provider.name.as_str());
+        let limiter = build_limiter(provider.max_rps);
         Self::spawn_loops(
             health.clone(),
             stop.clone(),
@@ -563,9 +680,49 @@ impl HealthMonitor {
             self.cfg.clone(),
             self.metrics.clone(),
         );
-        self.entries
-            .write()
-            .insert(provider.name.clone(), ProviderEntry { health, stop });
+        self.entries.write().insert(
+            provider.name.clone(),
+            ProviderEntry {
+                health,
+                limiter,
+                stop,
+            },
+        );
+    }
+
+    /// Reconcile a provider's rate cap on hot reload without disturbing its
+    /// health state. Installs, updates in place, or removes the limiter to match
+    /// the new `max_rps`. A no-op for a provider not currently tracked.
+    pub fn apply_rate_limit(&self, name: &str, max_rps: Option<u32>) {
+        let mut entries = self.entries.write();
+        let Some(entry) = entries.get_mut(name) else {
+            return;
+        };
+        match (max_rps, &entry.limiter) {
+            // Update the existing bucket in place (keeps its current tokens).
+            (Some(rps), Some(limiter)) => limiter.reconfigure(rps),
+            // Newly capped, or cap removed.
+            (Some(rps), None) => entry.limiter = Some(RateLimiter::new(rps)),
+            (None, Some(_)) => entry.limiter = None,
+            (None, None) => {}
+        }
+    }
+
+    /// Try to spend one rate-limit token before dispatching to `name`. Returns
+    /// `true` when the forward may proceed — always `true` for a provider with no
+    /// `max_rps` cap. A `false` means the bucket is empty (provider at capacity).
+    pub fn try_acquire(&self, name: &str) -> bool {
+        // Clone the Arc out under the entries read lock, then release it before
+        // taking the bucket lock — never hold two locks at once on the hot path.
+        let limiter = self
+            .entries
+            .read()
+            .get(name)
+            .and_then(|e| e.limiter.clone());
+        match limiter {
+            Some(l) => l.try_acquire(),
+            None => true,
+        }
     }
 
     /// Signal the background loops for this provider to exit and remove it.
@@ -618,20 +775,26 @@ impl HealthMonitor {
     /// score computation), so 1000s of concurrent requests proceed without
     /// queuing on each other.
     pub fn snapshots(&self) -> Vec<HealthSnapshot> {
-        let healths: Vec<Arc<ProviderHealth>> = self
+        let entries: Vec<(Arc<ProviderHealth>, Option<Arc<RateLimiter>>)> = self
             .entries
             .read()
             .values()
-            .map(|e| e.health.clone())
+            .map(|e| (e.health.clone(), e.limiter.clone()))
             .collect();
         let mut tips = SlotTips::default();
-        for h in &healths {
+        for (h, _) in &entries {
             tips.observe(&h.inner.read().slots);
         }
         tips.observe(&self.reference_slots.read());
-        healths
+        entries
             .iter()
-            .map(|h| h.snapshot(&tips, &self.cfg))
+            .map(|(h, limiter)| {
+                let mut snap = h.snapshot(&tips, &self.cfg);
+                // Peek the bucket (no token spent): an empty bucket marks the
+                // provider rate-limited so `is_available` sheds it from routing.
+                snap.rate_limited = limiter.as_ref().is_some_and(|l| !l.has_capacity());
+                snap
+            })
             .collect()
     }
 
@@ -791,6 +954,7 @@ async fn reference_loop(
         weight: 0,
         http3: false,
         methods: None,
+        max_rps: None,
     };
     info!(reference = %reference.url, "external slot reference enabled (probe-only, never routed)");
 
@@ -1248,6 +1412,7 @@ mod tests {
             weight: 1,
             http3: false,
             methods: None,
+            max_rps: None,
         };
         let monitor = HealthMonitor::new(
             std::slice::from_ref(&provider),
@@ -1259,10 +1424,14 @@ mod tests {
         {
             let stop = Arc::new(AtomicBool::new(false));
             let health = ProviderHealth::new("p");
-            monitor
-                .entries
-                .write()
-                .insert("p".to_string(), ProviderEntry { health, stop });
+            monitor.entries.write().insert(
+                "p".to_string(),
+                ProviderEntry {
+                    health,
+                    limiter: None,
+                    stop,
+                },
+            );
         }
         monitor.update_slot("p", 42_000);
         assert_eq!(monitor.slot_tip(), 42_000);
@@ -1279,15 +1448,20 @@ mod tests {
             weight: 1,
             http3: false,
             methods: None,
+            max_rps: None,
         };
         // We don't call add_provider here (needs real HTTP) — just verify map ops
         {
             let stop = Arc::new(AtomicBool::new(false));
             let health = ProviderHealth::new(provider.name.as_str());
-            monitor
-                .entries
-                .write()
-                .insert(provider.name.clone(), ProviderEntry { health, stop });
+            monitor.entries.write().insert(
+                provider.name.clone(),
+                ProviderEntry {
+                    health,
+                    limiter: None,
+                    stop,
+                },
+            );
         }
         assert_eq!(monitor.snapshots().len(), 1);
 
@@ -1441,6 +1615,7 @@ mod tests {
                 name.to_string(),
                 ProviderEntry {
                     health,
+                    limiter: None,
                     stop: Arc::new(AtomicBool::new(false)),
                 },
             );
@@ -1478,6 +1653,7 @@ mod tests {
             name.to_string(),
             ProviderEntry {
                 health,
+                limiter: None,
                 stop: Arc::new(AtomicBool::new(false)),
             },
         );
@@ -1642,5 +1818,131 @@ mod tests {
             "prior confirmed retained across a partial probe"
         );
         assert_eq!(snap.finalized.slot, Some(950));
+    }
+
+    // ── Per-provider rate limiting ─────────────────────────────────────────────
+
+    #[test]
+    fn token_bucket_drains_then_blocks() {
+        let mut b = TokenBucket::new(2); // capacity 2, starts full
+        assert!(b.try_acquire());
+        assert!(b.try_acquire());
+        // No time has passed, so nothing has refilled — the bucket is empty.
+        assert!(!b.try_acquire());
+        assert!(!b.has_capacity());
+    }
+
+    #[test]
+    fn token_bucket_refills_over_time() {
+        let mut b = TokenBucket::new(10); // 10 tokens/sec
+        b.tokens = 0.0;
+        // Pretend 200 ms elapsed → +2 tokens on the next refill.
+        b.last = Instant::now() - Duration::from_millis(200);
+        assert!(b.try_acquire(), "refill should have added ~2 tokens");
+        assert!(b.has_capacity(), "~1 token should remain");
+    }
+
+    #[test]
+    fn token_bucket_refill_capped_at_capacity() {
+        let mut b = TokenBucket::new(5);
+        b.tokens = 0.0;
+        b.last = Instant::now() - Duration::from_secs(100); // long idle
+        b.refill(Instant::now());
+        assert_eq!(b.tokens, 5.0, "refill must never exceed capacity");
+    }
+
+    #[test]
+    fn has_capacity_does_not_spend_a_token() {
+        let mut b = TokenBucket::new(1);
+        assert!(b.has_capacity());
+        assert!(b.has_capacity(), "peeking twice must not consume the token");
+        assert!(b.try_acquire(), "the token is still there to spend");
+        assert!(!b.try_acquire());
+    }
+
+    #[test]
+    fn reconfigure_clamps_tokens_to_new_capacity() {
+        let mut b = TokenBucket::new(100); // starts full at 100
+        b.reconfigure(10);
+        assert_eq!(b.capacity, 10.0);
+        assert_eq!(b.rate, 10.0);
+        assert!(b.tokens <= 10.0, "tokens clamped to the smaller ceiling");
+    }
+
+    /// Insert a provider with a fixed cap, bypassing the background loops.
+    fn insert_capped(monitor: &HealthMonitor, name: &str, max_rps: Option<u32>) {
+        let health = ProviderHealth::new(name);
+        monitor.entries.write().insert(
+            name.to_string(),
+            ProviderEntry {
+                health,
+                limiter: build_limiter(max_rps),
+                stop: Arc::new(AtomicBool::new(false)),
+            },
+        );
+    }
+
+    #[test]
+    fn snapshot_marks_exhausted_bucket_rate_limited() {
+        let monitor = HealthMonitor::new(&[], HealthConfig::default(), Metrics::new());
+        insert_capped(&monitor, "capped", Some(1));
+        // Fresh bucket holds a token → available, not rate-limited.
+        let snap = monitor.snapshots().into_iter().next().unwrap();
+        assert!(!snap.rate_limited);
+        assert!(snap.is_available());
+        // Spend the only token.
+        assert!(monitor.try_acquire("capped"));
+        // Empty bucket → snapshot marks it rate-limited and hence unavailable.
+        let snap = monitor.snapshots().into_iter().next().unwrap();
+        assert!(snap.rate_limited);
+        assert!(!snap.is_available());
+    }
+
+    #[test]
+    fn try_acquire_unlimited_provider_always_true() {
+        let monitor = HealthMonitor::new(&[], HealthConfig::default(), Metrics::new());
+        insert_capped(&monitor, "unlimited", None);
+        for _ in 0..1_000 {
+            assert!(monitor.try_acquire("unlimited"));
+        }
+        assert!(!monitor.snapshots()[0].rate_limited);
+    }
+
+    #[test]
+    fn try_acquire_unknown_provider_is_true() {
+        // A name with no entry (e.g. racing a removal) must never block dispatch.
+        let monitor = HealthMonitor::new(&[], HealthConfig::default(), Metrics::new());
+        assert!(monitor.try_acquire("ghost"));
+    }
+
+    #[test]
+    fn apply_rate_limit_installs_updates_and_removes() {
+        let monitor = HealthMonitor::new(&[], HealthConfig::default(), Metrics::new());
+        insert_capped(&monitor, "p", None);
+        // Unlimited to start.
+        for _ in 0..10 {
+            assert!(monitor.try_acquire("p"));
+        }
+        // Install a 1 rps cap.
+        monitor.apply_rate_limit("p", Some(1));
+        assert!(monitor.try_acquire("p"), "spend the starting token");
+        assert!(!monitor.try_acquire("p"), "now capped at 1 rps");
+        // Remove the cap → unlimited again.
+        monitor.apply_rate_limit("p", None);
+        for _ in 0..10 {
+            assert!(monitor.try_acquire("p"));
+        }
+    }
+
+    #[test]
+    fn apply_rate_limit_reconfigures_bucket_in_place() {
+        let monitor = HealthMonitor::new(&[], HealthConfig::default(), Metrics::new());
+        insert_capped(&monitor, "p", Some(100));
+        assert!(monitor.try_acquire("p")); // ~99 tokens left
+                                           // Shrink to 2 rps: the bucket is updated in place and its level clamped.
+        monitor.apply_rate_limit("p", Some(2));
+        assert!(monitor.try_acquire("p"));
+        assert!(monitor.try_acquire("p"));
+        assert!(!monitor.try_acquire("p"), "cap of 2 exhausted");
     }
 }

--- a/rpc-plane-core/src/metrics.rs
+++ b/rpc-plane-core/src/metrics.rs
@@ -11,6 +11,7 @@ struct Inner {
     requests: CounterVec,
     duration: HistogramVec,
     failovers: CounterVec,
+    rate_limited: CounterVec,
     probe_requests: CounterVec,
     health_score: GaugeVec,
     slot_height: GaugeVec,
@@ -56,6 +57,15 @@ impl Metrics {
                 "Requests retried on a different provider",
             ),
             &["from_provider", "to_provider"],
+        )
+        .unwrap();
+
+        let rate_limited = CounterVec::new(
+            Opts::new(
+                "rpc_plane_rate_limited_total",
+                "Requests shed from a provider because its max_rps token bucket was empty",
+            ),
+            &["provider"],
         )
         .unwrap();
 
@@ -140,6 +150,7 @@ impl Metrics {
             Box::new(requests.clone()) as Box<dyn prometheus::core::Collector>,
             Box::new(duration.clone()),
             Box::new(failovers.clone()),
+            Box::new(rate_limited.clone()),
             Box::new(probe_requests.clone()),
             Box::new(health_score.clone()),
             Box::new(slot_height.clone()),
@@ -164,6 +175,7 @@ impl Metrics {
             requests,
             duration,
             failovers,
+            rate_limited,
             probe_requests,
             health_score,
             slot_height,
@@ -201,6 +213,12 @@ impl Metrics {
 
     pub fn record_failover(&self, from: &str, to: &str) {
         self.0.failovers.with_label_values(&[from, to]).inc();
+    }
+
+    /// Count one request shed from `provider` because its `max_rps` bucket was
+    /// empty (the request routes to a peer, or serves anyway when degraded).
+    pub fn record_rate_limited(&self, provider: &str) {
+        self.0.rate_limited.with_label_values(&[provider]).inc();
     }
 
     pub fn record_probe(&self, provider: &str, probe_type: &str, status: &str) {
@@ -337,6 +355,18 @@ mod tests {
         assert!(text.contains(
             "rpc_plane_failover_total{from_provider=\"helius\",to_provider=\"triton\"} 2"
         ));
+    }
+
+    #[test]
+    fn rate_limited_counter() {
+        let m = Metrics::new();
+        m.record_rate_limited("helius");
+        m.record_rate_limited("helius");
+        m.record_rate_limited("triton");
+
+        let text = m.render();
+        assert!(text.contains("rpc_plane_rate_limited_total{provider=\"helius\"} 2"));
+        assert!(text.contains("rpc_plane_rate_limited_total{provider=\"triton\"} 1"));
     }
 
     #[test]

--- a/rpc-plane-core/src/proxy.rs
+++ b/rpc-plane-core/src/proxy.rs
@@ -248,6 +248,7 @@ async fn handle_health(State(state): State<ProxyState>) -> impl IntoResponse {
                 "error_rate": (s.error_rate * 1000.0).round() / 1000.0,
                 "circuit": format!("{:?}", s.circuit).to_lowercase(),
                 "available": s.is_available(),
+                "rate_limited": s.rate_limited,
                 "commitments": {
                     "processed": commitment(&s.processed),
                     "confirmed": commitment(&s.confirmed),
@@ -327,10 +328,16 @@ async fn handle_rpc(State(state): State<ProxyState>, headers: HeaderMap, body: B
         count: call_count,
     };
 
+    // A degraded decision means no provider was routable (all circuit-open
+    // and/or at their max_rps cap); the fallback lists every provider that
+    // supports the method. Bypass the per-provider rate gate for it so a lone or
+    // fully-capped fleet still serves rather than self-inflicting a 502; the
+    // normal path keeps the gate, shedding a capped provider's load to peers.
+    let rate_gate = !decision.degraded;
     if decision.broadcast {
-        broadcast(&state, &config, &decision.providers, ctx).await
+        broadcast(&state, &config, &decision.providers, ctx, rate_gate).await
     } else {
-        sequential(&state, &config, &decision.providers, ctx).await
+        sequential(&state, &config, &decision.providers, ctx, rate_gate).await
     }
 }
 
@@ -355,6 +362,7 @@ async fn sequential(
     config: &Config,
     providers: &[Arc<str>],
     ctx: RequestCtx<'_>,
+    rate_gate: bool,
 ) -> Response {
     let RequestCtx {
         method,
@@ -364,19 +372,16 @@ async fn sequential(
         count,
     } = ctx;
     let max_attempts = (config.routing.max_retries + 1).min(providers.len());
+    // Count of real forwards issued. Providers skipped before dispatch (missing
+    // client, or shed by the rate gate) do not consume an attempt, so a capped
+    // provider at the front of the list can't starve a healthy one behind it.
+    let mut attempt = 0usize;
     let mut prev_failed: Option<(Arc<str>, &'static str)> = None; // (name, reason)
     let recorder = state.recorder();
 
-    for (attempt, name) in providers.iter().enumerate().take(max_attempts) {
-        if attempt > 0 {
-            if let Some((ref from, reason)) = prev_failed {
-                state.metrics.record_failover(from, name);
-                state.reporter.emit(TelemetryEvent::Failover {
-                    from_provider: from.to_string(),
-                    to_provider: name.to_string(),
-                    reason: reason.to_string(),
-                });
-            }
+    for name in providers {
+        if attempt >= max_attempts {
+            break;
         }
 
         let Some(provider) = config
@@ -390,6 +395,39 @@ async fn sequential(
         let Some(client) = state.client_for(name) else {
             continue;
         };
+
+        // Per-provider rate cap. Only capped providers touch the bucket — the
+        // `max_rps.is_some()` guard short-circuits so an uncapped fleet takes no
+        // lock here (the default path pays one Option check). On the normal path
+        // an empty bucket sheds this request to the next provider without spending
+        // an attempt; a degraded decision (`rate_gate = false`) still drains the
+        // token but serves anyway.
+        if provider.max_rps.is_some() && !state.monitor.try_acquire(name) && rate_gate {
+            state.metrics.record_rate_limited(name);
+            warn!(
+                request_id = %request_id,
+                provider = %name,
+                method,
+                "provider at max_rps cap, shedding to next provider"
+            );
+            continue;
+        }
+
+        if attempt > 0 {
+            if let Some((ref from, reason)) = prev_failed {
+                state.metrics.record_failover(from, name);
+                state.reporter.emit(TelemetryEvent::Failover {
+                    from_provider: from.to_string(),
+                    to_provider: name.to_string(),
+                    reason: reason.to_string(),
+                });
+            }
+        }
+        // 0-based index of this forward; increment now so the retry `continue`s
+        // below carry the next attempt number.
+        let idx = attempt;
+        attempt += 1;
+
         let t0 = Instant::now();
         let result = forward(&client, provider, headers, body).await;
         let latency_ms = t0.elapsed().as_secs_f64() * 1000.0;
@@ -407,7 +445,7 @@ async fn sequential(
                         request_id = %request_id,
                         provider = %name,
                         method,
-                        attempt,
+                        attempt = idx,
                         status,
                         outcome = outcome.label(),
                         "retryable upstream status, trying next provider"
@@ -431,7 +469,7 @@ async fn sequential(
                         request_id = %request_id,
                         provider = %name,
                         method,
-                        attempt,
+                        attempt = idx,
                         status,
                         outcome = outcome.label(),
                         "upstream non-2xx, passing status through"
@@ -446,13 +484,13 @@ async fn sequential(
                 }
 
                 if let Some(code) = extract_rpc_error_code(&bytes) {
-                    if is_retryable_rpc_code(code) && attempt + 1 < max_attempts {
+                    if is_retryable_rpc_code(code) && attempt < max_attempts {
                         warn!(
                             request_id = %request_id,
                             provider = %name,
                             method,
                             code,
-                            attempt,
+                            attempt = idx,
                             "retryable RPC error, trying next provider"
                         );
                         recorder.record(method, name, Outcome::ProviderError, latency_ms, count);
@@ -464,7 +502,7 @@ async fn sequential(
                     request_id = %request_id,
                     provider = %name,
                     method,
-                    attempt,
+                    attempt = idx,
                     latency_ms = format!("{latency_ms:.1}"),
                     "request ok"
                 );
@@ -481,7 +519,7 @@ async fn sequential(
                     request_id = %request_id,
                     provider = %name,
                     method,
-                    attempt,
+                    attempt = idx,
                     error = %e,
                     "provider error, trying next"
                 );
@@ -502,6 +540,7 @@ async fn broadcast(
     config: &Config,
     providers: &[Arc<str>],
     ctx: RequestCtx<'_>,
+    rate_gate: bool,
 ) -> Response {
     let RequestCtx {
         method,
@@ -531,6 +570,20 @@ async fn broadcast(
         let Some(client) = state.client_for(name) else {
             continue;
         };
+        // Per-provider rate cap: a capped provider's leg is dropped from the fan-out
+        // on the normal path (a degraded decision bypasses the gate). The write still
+        // lands on every provider with headroom. The `max_rps.is_some()` guard keeps
+        // an uncapped fleet off the bucket lock entirely.
+        if provider.max_rps.is_some() && !state.monitor.try_acquire(name) && rate_gate {
+            state.metrics.record_rate_limited(name);
+            warn!(
+                request_id = %request_id,
+                provider = %name,
+                method,
+                "provider at max_rps cap, dropping broadcast leg"
+            );
+            continue;
+        }
         let provider = provider.clone();
         let headers = headers.clone();
         let body = body.clone();

--- a/rpc-plane-core/src/router.rs
+++ b/rpc-plane-core/src/router.rs
@@ -79,6 +79,12 @@ pub struct RouteDecision {
     /// For broadcasts all are contacted concurrently.
     pub providers: Vec<Arc<str>>,
     pub broadcast: bool,
+    /// True when no provider was routable (all circuit-open and/or at their
+    /// `max_rps` cap) and this list is the degraded last-resort fallback of every
+    /// provider that *supports* the method. The dispatch path bypasses the
+    /// per-provider rate gate for a degraded decision so a lone or fully-capped
+    /// fleet still serves rather than self-inflicting a 502.
+    pub degraded: bool,
 }
 
 /// Select providers given current health snapshots.
@@ -121,6 +127,7 @@ pub fn route(
                 .map(|s| s.name.clone())
                 .collect(),
             broadcast: broadcast_writes && class == MethodClass::Write,
+            degraded: true,
         };
     }
 
@@ -128,6 +135,7 @@ pub fn route(
         return RouteDecision {
             providers: available.iter().map(|s| s.name.clone()).collect(),
             broadcast: true,
+            degraded: false,
         };
     }
 
@@ -142,6 +150,7 @@ pub fn route(
             RouteDecision {
                 providers: available.iter().map(|s| s.name.clone()).collect(),
                 broadcast: false,
+                degraded: false,
             }
         }
 
@@ -182,6 +191,7 @@ pub fn route(
             RouteDecision {
                 providers: result,
                 broadcast: false,
+                degraded: false,
             }
         }
 
@@ -205,6 +215,7 @@ pub fn route(
             RouteDecision {
                 providers: ordered.iter().map(|s| s.name.clone()).collect(),
                 broadcast: false,
+                degraded: false,
             }
         }
 
@@ -218,6 +229,7 @@ pub fn route(
             RouteDecision {
                 providers: available.iter().map(|s| s.name.clone()).collect(),
                 broadcast: true, // use broadcast path but return on first success
+                degraded: false,
             }
         }
     }
@@ -244,6 +256,7 @@ mod tests {
             processed: CommitmentHealth::default(),
             confirmed: CommitmentHealth::default(),
             finalized: CommitmentHealth::default(),
+            rate_limited: false,
         }
     }
 
@@ -260,6 +273,15 @@ mod tests {
             processed: CommitmentHealth::default(),
             confirmed: CommitmentHealth::default(),
             finalized: CommitmentHealth::default(),
+            rate_limited: false,
+        }
+    }
+
+    /// A healthy provider whose `max_rps` bucket is currently empty.
+    fn snap_rate_limited(name: &str, score: f64) -> HealthSnapshot {
+        HealthSnapshot {
+            rate_limited: true,
+            ..snap(name, score)
         }
     }
 
@@ -272,6 +294,7 @@ mod tests {
                 weight: 1,
                 http3: false,
                 methods: None,
+                max_rps: None,
             })
             .collect()
     }
@@ -576,6 +599,58 @@ mod tests {
         );
         // getSlot can't go to the submit-only provider even in the degraded path.
         assert_eq!(names(&d), ["read"]);
+    }
+
+    #[test]
+    fn rate_limited_provider_excluded_from_reads() {
+        // "b" is at its max_rps cap → routed around, even with the best score.
+        let snaps = vec![snap("a", 0.6), snap_rate_limited("b", 0.9), snap("c", 0.5)];
+        let d = route(
+            "getSlot",
+            &snaps,
+            &RoutingStrategy::BestScore,
+            &providers(&["a", "b", "c"]),
+            false,
+            &writes(),
+        );
+        assert!(!d.providers.iter().any(|p| p.as_ref() == "b"));
+        assert_eq!(&*d.providers[0], "a");
+        assert!(!d.degraded);
+    }
+
+    #[test]
+    fn all_rate_limited_returns_degraded_fallback() {
+        // Every provider is at capacity: the router still returns them all, but
+        // marks the decision degraded so dispatch bypasses the rate gate and
+        // serves rather than 502-ing.
+        let snaps = vec![snap_rate_limited("a", 0.9), snap_rate_limited("b", 0.7)];
+        let d = route(
+            "getSlot",
+            &snaps,
+            &RoutingStrategy::BestScore,
+            &providers(&["a", "b"]),
+            false,
+            &writes(),
+        );
+        assert_eq!(d.providers.len(), 2);
+        assert!(
+            d.degraded,
+            "all-capped fleet must degrade, not drop requests"
+        );
+    }
+
+    #[test]
+    fn normal_decision_is_not_degraded() {
+        let snaps = vec![snap("a", 0.9), snap("b", 0.7)];
+        let d = route(
+            "getSlot",
+            &snaps,
+            &RoutingStrategy::BestScore,
+            &providers(&["a", "b"]),
+            false,
+            &writes(),
+        );
+        assert!(!d.degraded);
     }
 
     #[test]

--- a/rpc-plane-core/tests/integration.rs
+++ b/rpc-plane-core/tests/integration.rs
@@ -90,6 +90,7 @@ fn test_config(
                 weight: 1,
                 http3: false,
                 methods: None,
+                max_rps: None,
             })
             .collect(),
         reporting: None,
@@ -469,6 +470,7 @@ async fn circuit_recovers_traffic_resumes() {
                 weight: 1,
                 http3: false,
                 methods: None,
+                max_rps: None,
             },
             ProviderConfig {
                 name: "b".into(),
@@ -476,6 +478,7 @@ async fn circuit_recovers_traffic_resumes() {
                 weight: 1,
                 http3: false,
                 methods: None,
+                max_rps: None,
             },
         ],
         reporting: None,
@@ -971,5 +974,99 @@ async fn rate_limited_provider_demoted_but_circuit_stays_closed() {
         "throttled provider must be demoted (a={}, b={})",
         a.score,
         b.score
+    );
+}
+
+// ── Per-provider max_rps rate limiting ──────────────────────────────────────────
+
+/// A mock answering every POST with `slot`, counting only the POSTs whose body
+/// contains `needle`. Reads use `getBalance` as the needle so the background
+/// `getSlot` health probe (which never touches the rate bucket) isn't counted.
+async fn start_counting_mock(
+    slot: u64,
+    needle: &'static str,
+) -> (String, Arc<AtomicUsize>, tokio::task::AbortHandle) {
+    let count = Arc::new(AtomicUsize::new(0));
+    let c = count.clone();
+    let router = Router::new().route(
+        "/",
+        post(move |body: axum::body::Bytes| {
+            let c = c.clone();
+            async move {
+                if std::str::from_utf8(&body).is_ok_and(|s| s.contains(needle)) {
+                    c.fetch_add(1, Ordering::Relaxed);
+                }
+                slot_response(slot)
+            }
+        }),
+    );
+    let (url, abort) = start_mock(router).await;
+    (url, count, abort)
+}
+
+/// A provider at its `max_rps` cap is treated as unavailable: once its one-token
+/// bucket drains, the next read sheds to an uncapped peer rather than hammering
+/// the capped provider. FailoverOrdered keeps A preferred while it has capacity.
+#[tokio::test]
+async fn max_rps_sheds_request_to_uncapped_peer() {
+    let (url_a, count_a, _aa) = start_counting_mock(1, "getBalance").await;
+    let (url_b, count_b, _ab) = start_counting_mock(2, "getBalance").await;
+
+    let mut cfg = test_config(
+        &[("a", &url_a), ("b", &url_b)],
+        RoutingStrategy::FailoverOrdered,
+        2, // allow a retry to the peer
+        5,
+    );
+    cfg.providers[0].max_rps = Some(1);
+    let state = ProxyState::new(cfg);
+    let router = build_router(state);
+
+    // Request 1: A has its starting token → served by A.
+    let (s1, _) = proxy_request(router.clone(), GET_BALANCE).await;
+    assert_eq!(s1, StatusCode::OK);
+    // Request 2: A's bucket is empty → A is unavailable, the read sheds to B.
+    let (s2, _) = proxy_request(router.clone(), GET_BALANCE).await;
+    assert_eq!(s2, StatusCode::OK);
+
+    assert_eq!(
+        count_a.load(Ordering::Relaxed),
+        1,
+        "A serves exactly one read before its cap"
+    );
+    assert_eq!(
+        count_b.load(Ordering::Relaxed),
+        1,
+        "the second read sheds to the uncapped peer"
+    );
+}
+
+/// With only one provider, its `max_rps` cap must never hard-fail a request:
+/// there is no peer to shed to, so the degraded path forwards it anyway rather
+/// than returning 502. The cap is a load-shedding hint, not a hard throttle.
+#[tokio::test]
+async fn max_rps_lone_provider_still_serves_when_capped() {
+    let (url_a, count_a, _aa) = start_counting_mock(9, "getBalance").await;
+
+    let mut cfg = test_config(&[("a", &url_a)], RoutingStrategy::FailoverOrdered, 2, 5);
+    cfg.providers[0].max_rps = Some(1);
+    let state = ProxyState::new(cfg);
+    let router = build_router(state);
+
+    // Two reads back to back: the second finds an empty bucket but, with no peer,
+    // the router degrades and serves it anyway.
+    let (s1, _) = proxy_request(router.clone(), GET_BALANCE).await;
+    let (s2, b2) = proxy_request(router.clone(), GET_BALANCE).await;
+    assert_eq!(s1, StatusCode::OK);
+    assert_eq!(
+        s2,
+        StatusCode::OK,
+        "a lone capped provider must still serve, not 502"
+    );
+    assert_eq!(b2["result"].as_u64(), Some(9));
+    assert_eq!(
+        count_a.load(Ordering::Relaxed),
+        2,
+        "both reads reach the lone provider"
     );
 }

--- a/rpc-plane/src/main.rs
+++ b/rpc-plane/src/main.rs
@@ -464,6 +464,24 @@ async fn watch_config(
             info!(provider = %name, reason, "hot reload: provider client (re)built");
         }
 
+        // max_rps is a routing-only knob (like weight): it needs no client
+        // rebuild, but the token bucket lives on the monitor, so push any change
+        // in place — updating the bucket without disturbing the provider's health
+        // state. Added/rebuilt providers already got their limiter above; this
+        // catches a standalone cap change on an otherwise-unchanged provider.
+        for (name, new_p) in &new_providers {
+            let old_rps = old_providers.get(name).and_then(|p| p.max_rps);
+            if old_rps != new_p.max_rps {
+                monitor.apply_rate_limit(name, new_p.max_rps);
+                info!(
+                    provider = %name,
+                    old = ?old_rps,
+                    new = ?new_p.max_rps,
+                    "hot reload: max_rps changed"
+                );
+            }
+        }
+
         // Warn about settings that need a restart to take effect (the runtime
         // and listening sockets are already built).
         if old_server.listen != new_config.server.listen
@@ -626,6 +644,7 @@ mod tests {
             weight: 1,
             http3,
             methods: None,
+            max_rps: None,
         }
     }
 


### PR DESCRIPTION
## What

Adds an optional per-provider `max_rps` cap. A capped provider gets a token bucket (one second of capacity, refilled at `max_rps`/s). Once it is dispatching at its cap the bucket empties and the provider is marked **rate-limited → unavailable**, so the router shifts new requests to peers with headroom — the same way it routes around a demoted health score or an open circuit.

```toml
[[providers]]
name    = "free-key"
url     = "https://…"
max_rps = 10   # omit for unlimited
```

## Behavior

- **Load-shedding hint, not a hard throttle.** If every provider that can serve a method is at its cap, the proxy takes its existing degraded fallback and forwards anyway rather than returning an error — so a single at-capacity provider (or a single-provider deployment) never self-inflicts a 502. The cap only bites when there is a peer with headroom to shed to.
- **Per-provider, not per-method** — all methods draw from one bucket (per-method limits out of scope).
- **Zero cost when unused.** The dispatch gate is guarded by `max_rps.is_some()`, so an uncapped fleet takes no bucket lock — just one `Option` check per forward. Benched `route()` is unchanged.
- **Hot-reloadable** in place (updates the bucket without disturbing health state or rebuilding the client).

## Surfaces

- `/health`: each provider gains `"rate_limited": bool` (and `"available"` reflects it)
- New metric `rpc_plane_rate_limited_total{provider}` counts shed requests
- Config validation rejects `max_rps = 0`

## Testing

`cargo fmt`/`clippy` clean. 122 unit + 25 integration tests pass, including two new end-to-end tests: one proving a capped provider sheds to an uncapped peer, one proving a lone capped provider still serves (degraded bypass). Docs and examples updated to match.