### PR TITLE
update crossbeam-epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
```
cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1159 security advisories (from /home/i/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (293 crate dependencies)
Crate:     crossbeam-epoch
Version:   0.9.18
Title:     Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
Date:      2026-07-06
ID:        RUSTSEC-2026-0204
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0204
Solution:  Upgrade to >=0.9.20
Dependency tree:
crossbeam-epoch 0.9.18
└── crossbeam-deque 0.8.6
    └── rayon-core 1.13.0
        └── rayon 1.12.0
            └── criterion 0.5.1
                └── rpc-plane-core 0.10.0
                    └── rpc-plane 0.10.0

error: 1 vulnerability found!

```