### PR TITLE
examples/k8s: add NetworkPolicy to lock down the proxy port

### DIFF
--- a/examples/deploy/kubernetes/deployment.yaml
+++ b/examples/deploy/kubernetes/deployment.yaml
@@ -7,7 +7,9 @@
 #   kubectl apply -f deployment.yaml
 #
 # Keep the Service ClusterIP — RPC Plane is an internal component and should not
-# be exposed to the internet via a LoadBalancer or Ingress.
+# be exposed to the internet via a LoadBalancer or Ingress. The proxy has no
+# auth of its own, so the NetworkPolicy at the bottom gates the port at the
+# network layer: only pods you label rpc-plane-client="true" may reach it.
 ---
 apiVersion: v1
 kind: Secret
@@ -137,3 +139,35 @@ spec:
     - name: metrics
       port: 9401
       targetPort: metrics
+---
+# The proxy port is unauthenticated by design, so gate it at the network layer:
+# only pods explicitly labelled rpc-plane-client="true" may reach 9400, and only
+# the monitoring namespace may scrape 9401. Requires a CNI that enforces
+# NetworkPolicy (Calico, Cilium, most managed clusters). Delete this document if
+# your cluster gates traffic another way.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rpc-plane
+spec:
+  podSelector:
+    matchLabels:
+      app: rpc-plane
+  policyTypes: [Ingress]
+  ingress:
+    # App pods that may use the proxy — label them rpc-plane-client: "true".
+    - from:
+        - podSelector:
+            matchLabels:
+              rpc-plane-client: "true"
+      ports:
+        - { protocol: TCP, port: 9400 }
+    # Metrics scraping — allow 9401 from the namespace where Prometheus runs.
+    # kubernetes.io/metadata.name is the automatic namespace label (k8s ≥ 1.21);
+    # change "monitoring" to match your setup.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - { protocol: TCP, port: 9401 }

--- a/rpc-plane-core/src/router.rs
+++ b/rpc-plane-core/src/router.rs
@@ -16,8 +16,9 @@ pub enum MethodClass {
 /// Classify a method as a read or write given the configured write-method list.
 ///
 /// The list is operator-controlled (`routing.write_methods`); it defaults to
-/// `sendTransaction` + `simulateTransaction` so simulations route on the fast
-/// write path, but it can be overridden to add or remove methods.
+/// just `sendTransaction` — `simulateTransaction` is read-only and routes like a
+/// read unless explicitly added — but it can be overridden to add or remove
+/// methods.
 pub fn classify(method: &str, write_methods: &[String]) -> MethodClass {
     if write_methods.iter().any(|m| m == method) {
         MethodClass::Write


### PR DESCRIPTION
The proxy has no authentication on its listener by design — it is an internal component meant to sit inside your trust boundary. The standalone Kubernetes example now ships a `NetworkPolicy` so the port is gated at the network layer:

- ingress to `9400` only from pods labelled `rpc-plane-client: "true"`
- ingress to the metrics port `9401` only from the monitoring namespace

Also fixes a stale doc-comment in `router.rs`: `routing.write_methods` defaults to `["sendTransaction"]` only. The comment claimed it also included `simulateTransaction`, which is read-only and routes like a read unless explicitly added.

`cargo fmt --all --check`, `cargo clippy --all-targets`, and `cargo test --all` all pass. The manifest parses as valid multi-doc YAML (Secret, ConfigMap, Deployment, Service, NetworkPolicy).