### PR TITLE
feat: add opt-in historical getTransaction workload analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,42 @@ Run `rpc-plane init` to generate a full config with all options and their defaul
 
 See the [configuration reference](https://docs.rpcplane.dev/configuration/) for every option.
 
+### Historical RPC analytics
+
+Historical workload analytics is disabled by default. It is delivered as remote
+telemetry aggregates for the hosted dashboard and has no Prometheus surface, so
+it requires a configured `[reporting]` block. Add the block below to opt in to
+bounded analysis of `getTransaction` polling, result reuse, and slot age:
+
+```toml
+[historical_analytics]
+queue_capacity = 512
+max_queued_bytes = 67108864
+max_job_bytes = 2097152
+state_capacity = 250000
+state_ttl_secs = 172800
+flush_interval_ms = 60000
+```
+
+Starting without `[reporting]` is a config error rather than a silent no-op:
+the analyzer would otherwise consume a worker, a queue, and retained fingerprint
+state while emitting nowhere.
+
+`queue_capacity`, `max_queued_bytes`, and `max_job_bytes` bound queued analysis
+work; `state_capacity` and `state_ttl_secs` bound retained fingerprint state.
+Jobs that exceed these limits are dropped from analysis without affecting RPC
+responses. `max_job_bytes` must not exceed `max_queued_bytes`, and all limits
+must be positive.
+
+The analyzer does not cache or alter RPC responses and makes no additional RPC
+calls. Results are reported only as aggregate counts in the versioned
+`historical_get_transaction_aggregate` telemetry event; no historical metric is
+exposed on `/metrics`. It never exports raw signatures, addresses, request IDs, parameters,
+response bodies, or request fingerprints. Request state uses process-local keyed
+fingerprints; restarting RPC Plane changes the key and resets that state. These
+settings are restart-only and changes made by config hot reload do not take
+effect until the process restarts.
+
 ## CLI
 
 ```

--- a/benches/proxy_bench.rs
+++ b/benches/proxy_bench.rs
@@ -4,6 +4,8 @@
 mod config;
 #[path = "../src/health.rs"]
 mod health;
+#[path = "../src/historical.rs"]
+mod historical;
 #[path = "../src/metrics.rs"]
 mod metrics;
 #[path = "../src/proxy.rs"]
@@ -16,13 +18,20 @@ mod telemetry;
 mod tx;
 
 use crate::{
-    config::{ProviderConfig, RoutingStrategy},
-    health::{CircuitState, CommitmentHealth, HealthSnapshot},
+    config::{HistoricalAnalyticsConfig, ProviderConfig, RoutingStrategy},
+    health::{CircuitState, CommitmentHealth, HealthSnapshot, ObservedSlotTips},
+    historical::{
+        parse_response, AnalyzerCore, Fingerprint, HistoricalAnalytics, HistoricalCommitment,
+        HistoricalRequestClass,
+    },
     proxy::extract_method,
     router::{extract_rpc_error_code, route},
+    telemetry::{NoopReporter, Reporter},
 };
+use axum::body::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -132,10 +141,175 @@ fn bench_extract_rpc_error_code(c: &mut Criterion) {
     g.finish();
 }
 
+// ── Historical analytics ──────────────────────────────────────────────────────
+//
+// The analyzer must cost effectively nothing when the `[historical_analytics]`
+// block is absent, and must never parse a body on the request task when it is
+// present. `completion_path` covers both halves of the acceptance criteria:
+// `disabled` is the `Option` check the proxy performs per request, `enqueue` is
+// the full enabled hot path (bounds check, permit acquire, two `Bytes` clones,
+// `try_send`). Parsing, normalization, and state transitions are benched
+// separately because they run on the worker, not on the request task.
+
+const GET_TRANSACTION_REQUEST: &[u8] = br#"{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["5wHu1qwD4kLwYqBBiVLLxpDRTLNTvBhnvbSMPCkFYVjNSFPdKtxJmzZuLZ3g7VeMYS8Fw7yEbKAvbLHDrDF3xrf7",{"encoding":"json","commitment":"confirmed","maxSupportedTransactionVersion":0}]}"#;
+const FOUND_RESPONSE: &[u8] = br#"{"jsonrpc":"2.0","id":1,"result":{"slot":312894001,"blockTime":1731000000,"meta":{"err":null,"fee":5000,"preBalances":[100000,200000],"postBalances":[95000,200000]},"transaction":{"signatures":["5wHu1qwD4kLwYqBBiVLLxpDRTLNTvBhnvbSMPCkFYVjNSFPdKtxJmzZuLZ3g7VeMYS8Fw7yEbKAvbLHDrDF3xrf7"],"message":{"accountKeys":["11111111111111111111111111111111"]}}}}"#;
+const NULL_RESPONSE: &[u8] = br#"{"jsonrpc":"2.0","id":1,"result":null}"#;
+
+fn bench_historical_completion_path(c: &mut Criterion) {
+    let request = Bytes::from_static(GET_TRANSACTION_REQUEST);
+    let response = Bytes::from_static(FOUND_RESPONSE);
+    let tips = ObservedSlotTips::default();
+
+    // Multi-threaded so the worker actually drains the queue; a saturated queue
+    // would measure the drop path instead of the enqueue path.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+    let _guard = rt.enter();
+
+    let disabled: Option<HistoricalAnalytics> = None;
+    let reporter: Arc<dyn Reporter> = Arc::new(NoopReporter);
+    let enabled = Some(HistoricalAnalytics::new(
+        HistoricalAnalyticsConfig::default(),
+        reporter,
+    ));
+
+    let mut g = c.benchmark_group("historical/completion_path");
+    g.bench_function("disabled", |b| {
+        b.iter(|| {
+            if let Some(analytics) = black_box(&disabled) {
+                analytics.finish(
+                    HistoricalRequestClass::Single,
+                    &request,
+                    &response,
+                    200,
+                    tips,
+                );
+            }
+        })
+    });
+    g.bench_function("enqueue", |b| {
+        b.iter(|| {
+            if let Some(analytics) = black_box(&enabled) {
+                analytics.finish(
+                    black_box(HistoricalRequestClass::Single),
+                    black_box(&request),
+                    black_box(&response),
+                    200,
+                    black_box(tips),
+                );
+            }
+        })
+    });
+    g.bench_function("ineligible_method", |b| {
+        b.iter(|| {
+            if let Some(analytics) = black_box(&enabled) {
+                analytics.finish(
+                    black_box(HistoricalRequestClass::None),
+                    black_box(&request),
+                    black_box(&response),
+                    200,
+                    black_box(tips),
+                );
+            }
+        })
+    });
+    g.finish();
+}
+
+fn bench_historical_parse_response(c: &mut Criterion) {
+    let mut g = c.benchmark_group("historical/parse_response");
+    g.bench_function("found", |b| {
+        b.iter(|| parse_response(black_box(200), black_box(FOUND_RESPONSE)))
+    });
+    g.bench_function("null", |b| {
+        b.iter(|| parse_response(black_box(200), black_box(NULL_RESPONSE)))
+    });
+    g.finish();
+}
+
+fn bench_historical_fingerprint(c: &mut Criterion) {
+    let core = AnalyzerCore::new(250_000, 172_800);
+    let request: serde_json::Value = serde_json::from_slice(GET_TRANSACTION_REQUEST).unwrap();
+
+    let mut g = c.benchmark_group("historical/fingerprint");
+    // Worker-side cost of turning a request body into a keyed fingerprint: the
+    // JSON parse the request task deliberately avoids, plus normalize + hash.
+    g.bench_function("parse_and_hash", |b| {
+        b.iter(|| {
+            let value: serde_json::Value =
+                serde_json::from_slice(black_box(GET_TRANSACTION_REQUEST)).unwrap();
+            core.fingerprint(black_box(&value))
+        })
+    });
+    g.bench_function("hash_only", |b| {
+        b.iter(|| core.fingerprint(black_box(&request)))
+    });
+    g.finish();
+}
+
+fn bench_historical_transition(c: &mut Criterion) {
+    let commitment = HistoricalCommitment::Confirmed;
+    let start = Instant::now();
+
+    let mut g = c.benchmark_group("historical/transition");
+    // At capacity every insert also evicts, which is the steady state for a
+    // long-running proxy whose working set exceeds `state_capacity`.
+    g.bench_function("at_capacity_with_eviction", |b| {
+        let capacity = 10_000;
+        let mut core = AnalyzerCore::new(capacity, 172_800);
+        for i in 0..capacity as u64 {
+            core.transition(
+                Fingerprint(i, i),
+                commitment,
+                false,
+                None,
+                start + Duration::from_millis(i),
+            );
+        }
+        let mut i = capacity as u64;
+        b.iter(|| {
+            i += 1;
+            core.transition(
+                black_box(Fingerprint(i, i)),
+                commitment,
+                false,
+                None,
+                start + Duration::from_millis(i),
+            );
+        })
+    });
+    // The found -> found repeat is the strong positive-cache signal, so its
+    // per-observation cost is the one that matters most at high reuse rates.
+    g.bench_function("found_repeat", |b| {
+        let mut core = AnalyzerCore::new(10_000, 172_800);
+        let fingerprint = Fingerprint(7, 7);
+        core.transition(fingerprint, commitment, true, Some(1), start);
+        let mut i = 0u64;
+        b.iter(|| {
+            i += 1;
+            core.transition(
+                black_box(fingerprint),
+                commitment,
+                true,
+                Some(1),
+                start + Duration::from_millis(i),
+            );
+        })
+    });
+    g.finish();
+}
+
 criterion_group!(
     benches,
     bench_extract_method,
     bench_route,
-    bench_extract_rpc_error_code
+    bench_extract_rpc_error_code,
+    bench_historical_completion_path,
+    bench_historical_parse_response,
+    bench_historical_fingerprint,
+    bench_historical_transition
 );
 criterion_main!(benches);

--- a/config.example.toml
+++ b/config.example.toml
@@ -82,3 +82,20 @@ weight = 1
 # flush_interval_ms = 60000  # aggregate window + POST interval (ms)
 # buffer_size       = 1000   # max buffered events (oldest dropped when full)
 # batch_size        = 100    # max events per HTTP POST
+
+# ── Historical RPC analytics ───────────────────────────────────────────────────
+# Opt-in: presence of this block enables bounded analysis of getTransaction
+# workloads. Requires [reporting] above — results are delivered only as remote
+# telemetry aggregates for the hosted dashboard and are not exposed on /metrics.
+# It observes polling and successful-response reuse but does not cache,
+# alter, delay, or make additional RPC requests. Raw signatures, addresses,
+# request IDs, parameters, response bodies, and internal fingerprints are never
+# exported. The process-local keyed state resets whenever RPC Plane restarts.
+# All settings are restart-only; config hot reload does not apply changes here.
+# [historical_analytics]
+# queue_capacity   = 512       # maximum queued analysis jobs
+# max_queued_bytes = 67108864  # total queued request/response byte budget (64 MiB)
+# max_job_bytes    = 2097152   # largest accepted analysis job (2 MiB; <= queued budget)
+# state_capacity   = 250000    # maximum retained request fingerprints
+# state_ttl_secs   = 172800    # expire fingerprint lifecycle state after 48 hours
+# flush_interval_ms = 60000    # aggregate flush interval

--- a/scripts/check-docs-coverage.sh
+++ b/scripts/check-docs-coverage.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Asserts that every serde-deserialized field in the user-facing config structs
-# (ServerConfig, HealthConfig, RoutingConfig, ProviderConfig) is mentioned in the
+# (ServerConfig, HealthConfig, RoutingConfig, ProviderConfig, and
+# HistoricalAnalyticsConfig) is mentioned in the
 # documentation. This automates the docs-sync rule: a flag that lands in
 # config.rs without a matching entry in configuration.md fails the build.
 #
@@ -26,11 +27,11 @@ if [[ ! -f "$DOCS" ]]; then
   exit 2
 fi
 
-# Extract the serde field name of every `pub` field inside the four user-facing
+# Extract the serde field name of every `pub` field inside the user-facing
 # config structs. A field-level #[serde(rename = "...")] wins over the Rust name.
 # Uses only POSIX awk features so it runs under both mawk and gawk.
 fields="$(awk '
-  /^pub struct (ServerConfig|HealthConfig|RoutingConfig|ProviderConfig) \{/ { in_s=1; rename=""; next }
+  /^pub struct (ServerConfig|HealthConfig|RoutingConfig|ProviderConfig|HistoricalAnalyticsConfig) \{/ { in_s=1; rename=""; next }
   in_s && /^\}/                                                            { in_s=0; rename=""; next }
   !in_s { next }
   /#\[serde\(rename = "/ {

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     pub providers: Vec<ProviderConfig>,
     #[serde(default)]
     pub reporting: Option<ReportingConfig>,
+    #[serde(default)]
+    pub historical_analytics: Option<HistoricalAnalyticsConfig>,
 }
 
 impl Config {
@@ -87,6 +89,49 @@ impl Config {
                 "reporting.flush_interval_ms must be >= 10000 (10 s); got {}. \
                  Values below 10 s produce excessive telemetry volume.",
                 r.flush_interval_ms
+            );
+        }
+        if let Some(h) = &self.historical_analytics {
+            // The aggregate telemetry event is the only delivery path for
+            // historical analysis — it is not exported to Prometheus. Without a
+            // reporter the analyzer would run a worker, a queue, and up to
+            // `state_capacity` retained fingerprints while emitting into a
+            // no-op sink, with nothing anywhere to reveal it. Fail fast instead.
+            anyhow::ensure!(
+                self.reporting.is_some(),
+                "historical_analytics requires [reporting]: analysis is delivered \
+                 only as remote telemetry aggregates, so without a reporting \
+                 endpoint the analyzer would consume resources and report nothing"
+            );
+            anyhow::ensure!(
+                h.queue_capacity > 0,
+                "historical_analytics.queue_capacity must be positive"
+            );
+            anyhow::ensure!(
+                h.max_queued_bytes >= 4096,
+                "historical_analytics.max_queued_bytes must be at least 4096"
+            );
+            anyhow::ensure!(
+                h.max_job_bytes > 0,
+                "historical_analytics.max_job_bytes must be positive"
+            );
+            anyhow::ensure!(
+                h.state_capacity > 0,
+                "historical_analytics.state_capacity must be positive"
+            );
+            anyhow::ensure!(
+                h.state_ttl_secs > 0,
+                "historical_analytics.state_ttl_secs must be positive"
+            );
+            anyhow::ensure!(
+                h.flush_interval_ms > 0,
+                "historical_analytics.flush_interval_ms must be positive"
+            );
+            anyhow::ensure!(
+                h.max_job_bytes <= h.max_queued_bytes,
+                "historical_analytics.max_job_bytes ({}) must be <= max_queued_bytes ({})",
+                h.max_job_bytes,
+                h.max_queued_bytes
             );
         }
         Ok(())
@@ -399,6 +444,58 @@ fn default_buffer_size() -> usize {
 }
 fn default_batch_size() -> usize {
     100
+}
+
+// ── Historical analytics ────────────────────────────────────────────────────
+
+/// Optional bounded analysis of historical RPC workloads. Presence of the
+/// `[historical_analytics]` block enables the feature.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct HistoricalAnalyticsConfig {
+    #[serde(default = "default_historical_queue_capacity")]
+    pub queue_capacity: usize,
+    #[serde(default = "default_historical_max_queued_bytes")]
+    pub max_queued_bytes: usize,
+    #[serde(default = "default_historical_max_job_bytes")]
+    pub max_job_bytes: usize,
+    #[serde(default = "default_historical_state_capacity")]
+    pub state_capacity: usize,
+    #[serde(default = "default_historical_state_ttl_secs")]
+    pub state_ttl_secs: u64,
+    #[serde(default = "default_historical_flush_interval_ms")]
+    pub flush_interval_ms: u64,
+}
+
+impl Default for HistoricalAnalyticsConfig {
+    fn default() -> Self {
+        Self {
+            queue_capacity: default_historical_queue_capacity(),
+            max_queued_bytes: default_historical_max_queued_bytes(),
+            max_job_bytes: default_historical_max_job_bytes(),
+            state_capacity: default_historical_state_capacity(),
+            state_ttl_secs: default_historical_state_ttl_secs(),
+            flush_interval_ms: default_historical_flush_interval_ms(),
+        }
+    }
+}
+
+fn default_historical_queue_capacity() -> usize {
+    512
+}
+fn default_historical_max_queued_bytes() -> usize {
+    67_108_864
+}
+fn default_historical_max_job_bytes() -> usize {
+    2_097_152
+}
+fn default_historical_state_capacity() -> usize {
+    250_000
+}
+fn default_historical_state_ttl_secs() -> u64 {
+    172_800
+}
+fn default_historical_flush_interval_ms() -> u64 {
+    60_000
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -714,6 +811,122 @@ api_key = "rp_live_test"
         let f = write_config("[[providers]]\nname=\"p\"\nurl=\"http://x\"\n");
         let cfg = Config::load(f.path()).unwrap();
         assert!(cfg.reporting.is_none());
+    }
+
+    #[test]
+    fn historical_analytics_absent_is_none() {
+        let f = write_config("[[providers]]\nname=\"p\"\nurl=\"http://x\"\n");
+        let cfg = Config::load(f.path()).unwrap();
+        assert!(cfg.historical_analytics.is_none());
+    }
+
+    #[test]
+    fn historical_analytics_empty_block_uses_defaults() {
+        let f = write_config(
+            r#"
+[historical_analytics]
+
+[reporting]
+endpoint = "http://localhost:3000/api/ingest"
+api_key = "rp_live_test"
+
+[[providers]]
+name = "p"
+url = "http://x"
+"#,
+        );
+        let cfg = Config::load(f.path()).unwrap();
+        assert_eq!(
+            cfg.historical_analytics,
+            Some(HistoricalAnalyticsConfig::default())
+        );
+    }
+
+    #[test]
+    fn parses_custom_historical_analytics_config() {
+        let f = write_config(
+            r#"
+[historical_analytics]
+queue_capacity = 12
+max_queued_bytes = 4096
+max_job_bytes = 1024
+state_capacity = 34
+state_ttl_secs = 56
+flush_interval_ms = 78
+
+[reporting]
+endpoint = "http://localhost:3000/api/ingest"
+api_key = "rp_live_test"
+
+[[providers]]
+name = "p"
+url = "http://x"
+"#,
+        );
+        let cfg = Config::load(f.path()).unwrap();
+        assert_eq!(
+            cfg.historical_analytics,
+            Some(HistoricalAnalyticsConfig {
+                queue_capacity: 12,
+                max_queued_bytes: 4096,
+                max_job_bytes: 1024,
+                state_capacity: 34,
+                state_ttl_secs: 56,
+                flush_interval_ms: 78,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_historical_analytics_without_reporting() {
+        // Analysis ships only as remote aggregates, so this pairing would burn
+        // analyzer resources into a NoopReporter and surface nowhere.
+        let f = write_config(
+            "[historical_analytics]\n[[providers]]\nname = \"p\"\nurl = \"http://x\"\n",
+        );
+        let err = Config::load(f.path()).unwrap_err().to_string();
+        assert!(err.contains("requires [reporting]"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_invalid_historical_analytics_config() {
+        let zero_cases = [
+            "queue_capacity",
+            "max_queued_bytes",
+            "max_job_bytes",
+            "state_capacity",
+            "state_ttl_secs",
+            "flush_interval_ms",
+        ];
+
+        for field in zero_cases {
+            let f = write_config(&format!(
+                "[historical_analytics]\n{field} = 0\n\
+                 [reporting]\nendpoint = \"http://x/i\"\napi_key = \"k\"\n\
+                 [[providers]]\nname = \"p\"\nurl = \"http://x\"\n"
+            ));
+            let err = Config::load(f.path()).unwrap_err().to_string();
+            assert!(err.contains(field), "field={field}, got: {err}");
+        }
+
+        let f = write_config(
+            r#"
+[historical_analytics]
+max_queued_bytes = 4096
+max_job_bytes = 4097
+
+[reporting]
+endpoint = "http://localhost:3000/api/ingest"
+api_key = "rp_live_test"
+
+[[providers]]
+name = "p"
+url = "http://x"
+"#,
+        );
+        let err = Config::load(f.path()).unwrap_err().to_string();
+        assert!(err.contains("max_job_bytes"), "got: {err}");
+        assert!(err.contains("max_queued_bytes"), "got: {err}");
     }
 
     #[test]

--- a/src/health.rs
+++ b/src/health.rs
@@ -185,7 +185,24 @@ impl CommitmentSlots {
             self.finalized = new.finalized;
         }
     }
+
+    fn observe_max(&mut self, slots: &CommitmentSlots) {
+        self.processed = max_option(self.processed, slots.processed);
+        self.confirmed = max_option(self.confirmed, slots.confirmed);
+        self.finalized = max_option(self.finalized, slots.finalized);
+    }
 }
+
+fn max_option(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (a, b) => a.or(b),
+    }
+}
+
+/// Optional network tips captured in the same read pass as routing snapshots.
+/// Unlike [`SlotTips`], absence remains explicit for historical age telemetry.
+pub type ObservedSlotTips = CommitmentSlots;
 
 /// Network tip per commitment = max slot across all providers at that level.
 #[derive(Debug, Clone, Copy, Default)]
@@ -778,6 +795,12 @@ impl HealthMonitor {
     /// score computation), so 1000s of concurrent requests proceed without
     /// queuing on each other.
     pub fn snapshots(&self) -> Vec<HealthSnapshot> {
+        self.snapshots_with_tips().0
+    }
+
+    /// Current routing snapshots and the per-commitment network tips used to
+    /// build them, collected from one pass over provider health state.
+    pub fn snapshots_with_tips(&self) -> (Vec<HealthSnapshot>, ObservedSlotTips) {
         let entries: Vec<(Arc<ProviderHealth>, Option<Arc<RateLimiter>>)> = self
             .entries
             .read()
@@ -785,11 +808,16 @@ impl HealthMonitor {
             .map(|e| (e.health.clone(), e.limiter.clone()))
             .collect();
         let mut tips = SlotTips::default();
+        let mut observed_tips = ObservedSlotTips::default();
         for (h, _) in &entries {
-            tips.observe(&h.inner.read().slots);
+            let slots = h.inner.read().slots;
+            tips.observe(&slots);
+            observed_tips.observe_max(&slots);
         }
-        tips.observe(&self.reference_slots.read());
-        entries
+        let reference_slots = *self.reference_slots.read();
+        tips.observe(&reference_slots);
+        observed_tips.observe_max(&reference_slots);
+        let snapshots = entries
             .iter()
             .map(|(h, limiter)| {
                 let mut snap = h.snapshot(&tips, &self.cfg);
@@ -798,7 +826,8 @@ impl HealthMonitor {
                 snap.rate_limited = limiter.as_ref().is_some_and(|l| !l.has_capacity());
                 snap
             })
-            .collect()
+            .collect();
+        (snapshots, observed_tips)
     }
 
     /// Update the cached slot height for a named provider.

--- a/src/historical.rs
+++ b/src/historical.rs
@@ -1,0 +1,991 @@
+use crate::config::HistoricalAnalyticsConfig;
+use crate::health::ObservedSlotTips;
+use crate::telemetry::{
+    Reporter, TelemetryEvent, HISTORICAL_FOUND_REUSE_BUCKET_COUNT,
+    HISTORICAL_GET_TRANSACTION_AGGREGATE_VERSION, HISTORICAL_POLLS_BEFORE_FOUND_BUCKET_COUNT,
+    HISTORICAL_SLOT_AGE_BUCKET_COUNT, HISTORICAL_TIME_TO_FOUND_BUCKET_COUNT,
+};
+use axum::body::Bytes;
+use std::collections::{hash_map::RandomState, BTreeSet, HashMap};
+use std::hash::{BuildHasher, Hasher};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
+
+const QUEUE_BYTE_UNIT: usize = 4096;
+const REUSE_EPOCH_OBSERVATION_SECS: u64 = 172_800;
+
+// ── Classification vocabulary ────────────────────────────────────────────────
+//
+// These are the fixed classifications the analyzer reports. They are aggregated
+// into the versioned `HistoricalGetTransactionAggregate` telemetry event and
+// are deliberately not exported as Prometheus metrics: historical workload
+// analysis is a hosted-dashboard feature, so the aggregate event is the single
+// delivery path. Adding a variant is a telemetry schema change — bump
+// `HISTORICAL_GET_TRANSACTION_AGGREGATE_VERSION` when the meaning or order of
+// any reported bucket changes.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HistoricalCommitment {
+    Processed,
+    Confirmed,
+    Finalized,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HistoricalErrorKind {
+    Rpc,
+    Parse,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HistoricalTransition {
+    FirstObservationFound,
+    FirstObservationNull,
+    NullRepeat,
+    NullToFound,
+    FoundRepeat,
+    FoundToNullRegression,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HistoricalAnalyzerDropReason {
+    QueueFull,
+    ByteBudgetExhausted,
+    OversizedJob,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HistoricalStateEvictionReason {
+    Capacity,
+    Ttl,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HistoricalState {
+    NullSeen,
+    Found,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HistoricalRequestClass {
+    None,
+    Single,
+    Batch { eligible_calls: u64 },
+}
+
+impl HistoricalRequestClass {
+    fn eligible_calls(self) -> u64 {
+        match self {
+            Self::None => 0,
+            Self::Single => 1,
+            Self::Batch { eligible_calls } => eligible_calls,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HistoricalAnalytics {
+    sender: mpsc::Sender<Message>,
+    byte_budget: Arc<Semaphore>,
+    max_job_bytes: usize,
+    quality: Arc<QualityCounters>,
+}
+
+struct Job {
+    request: Bytes,
+    response: Bytes,
+    status: u16,
+    observed_at: Instant,
+    tips: ObservedSlotTips,
+    class: HistoricalRequestClass,
+    _permit: OwnedSemaphorePermit,
+}
+
+enum Message {
+    Analyze(Job),
+    Flush(oneshot::Sender<()>),
+}
+
+#[derive(Default)]
+struct QualityCounters {
+    dropped_logical: AtomicU64,
+    queue_full: AtomicU64,
+    byte_budget: AtomicU64,
+    oversized: AtomicU64,
+    resets: AtomicU64,
+}
+
+impl HistoricalAnalytics {
+    pub fn new(config: HistoricalAnalyticsConfig, reporter: Arc<dyn Reporter>) -> Self {
+        let (sender, receiver) = mpsc::channel(config.queue_capacity);
+        let permit_count = (config.max_queued_bytes / QUEUE_BYTE_UNIT).max(1);
+        let byte_budget = Arc::new(Semaphore::new(permit_count));
+        let quality = Arc::new(QualityCounters::default());
+        quality.resets.store(1, Ordering::Relaxed);
+
+        tokio::spawn(worker_loop(
+            receiver,
+            config.clone(),
+            reporter,
+            quality.clone(),
+        ));
+
+        Self {
+            sender,
+            byte_budget,
+            max_job_bytes: config.max_job_bytes,
+            quality,
+        }
+    }
+
+    pub fn finish(
+        &self,
+        class: HistoricalRequestClass,
+        request: &Bytes,
+        response: &Bytes,
+        status: u16,
+        tips: ObservedSlotTips,
+    ) {
+        let logical = class.eligible_calls();
+        if logical == 0 {
+            return;
+        }
+
+        let Some(job_bytes) = request.len().checked_add(response.len()) else {
+            self.drop_job(HistoricalAnalyzerDropReason::OversizedJob, logical);
+            return;
+        };
+        if job_bytes > self.max_job_bytes {
+            self.drop_job(HistoricalAnalyzerDropReason::OversizedJob, logical);
+            return;
+        }
+
+        let units = job_bytes.div_ceil(QUEUE_BYTE_UNIT).max(1);
+        let Ok(units) = u32::try_from(units) else {
+            self.drop_job(HistoricalAnalyzerDropReason::ByteBudgetExhausted, logical);
+            return;
+        };
+        let Ok(permit) = self.byte_budget.clone().try_acquire_many_owned(units) else {
+            self.drop_job(HistoricalAnalyzerDropReason::ByteBudgetExhausted, logical);
+            return;
+        };
+
+        let job = Job {
+            request: request.clone(),
+            response: response.clone(),
+            status,
+            observed_at: Instant::now(),
+            tips,
+            class,
+            _permit: permit,
+        };
+        if self.sender.try_send(Message::Analyze(job)).is_err() {
+            self.drop_job(HistoricalAnalyzerDropReason::QueueFull, logical);
+        }
+    }
+
+    fn drop_job(&self, reason: HistoricalAnalyzerDropReason, logical: u64) {
+        self.quality
+            .dropped_logical
+            .fetch_add(logical, Ordering::Relaxed);
+        match reason {
+            HistoricalAnalyzerDropReason::QueueFull => &self.quality.queue_full,
+            HistoricalAnalyzerDropReason::ByteBudgetExhausted => &self.quality.byte_budget,
+            HistoricalAnalyzerDropReason::OversizedJob => &self.quality.oversized,
+        }
+        .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub async fn flush(&self) {
+        let (done, receiver) = oneshot::channel();
+        if self.sender.send(Message::Flush(done)).await.is_ok() {
+            let _ = receiver.await;
+        }
+    }
+}
+
+async fn worker_loop(
+    mut receiver: mpsc::Receiver<Message>,
+    config: HistoricalAnalyticsConfig,
+    reporter: Arc<dyn Reporter>,
+    quality: Arc<QualityCounters>,
+) {
+    let mut core = AnalyzerCore::new(config.state_capacity, config.state_ttl_secs);
+    let mut interval = tokio::time::interval(Duration::from_millis(config.flush_interval_ms));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    interval.tick().await;
+
+    loop {
+        tokio::select! {
+            message = receiver.recv() => match message {
+                Some(Message::Analyze(job)) => core.process(job),
+                Some(Message::Flush(done)) => {
+                    core.expire(Instant::now());
+                    core.flush(&reporter, &quality, config.state_capacity);
+                    let _ = done.send(());
+                }
+                None => break,
+            },
+            _ = interval.tick() => {
+                core.expire(Instant::now());
+                core.flush(&reporter, &quality, config.state_capacity);
+            }
+        }
+    }
+    core.expire(Instant::now());
+    core.flush(&reporter, &quality, config.state_capacity);
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Fingerprint(pub(crate) u64, pub(crate) u64);
+
+enum Lifecycle {
+    NullSeen {
+        first_null_at: Instant,
+        null_poll_count: u64,
+    },
+    Found {
+        last_found_at: Instant,
+    },
+}
+
+struct StateEntry {
+    lifecycle: Lifecycle,
+    commitment: HistoricalCommitment,
+    last_seen_at: Instant,
+}
+
+pub(crate) struct AnalyzerCore {
+    state: HashMap<Fingerprint, StateEntry>,
+    lru: BTreeSet<(Instant, Fingerprint)>,
+    capacity: usize,
+    ttl: Duration,
+    hash_a: RandomState,
+    hash_b: RandomState,
+    windows: [Window; 4],
+    window_start_ms: u64,
+}
+
+impl AnalyzerCore {
+    pub(crate) fn new(capacity: usize, ttl_secs: u64) -> Self {
+        Self {
+            state: HashMap::with_capacity(capacity.min(16_384)),
+            lru: BTreeSet::new(),
+            capacity,
+            ttl: Duration::from_secs(ttl_secs),
+            hash_a: RandomState::new(),
+            hash_b: RandomState::new(),
+            windows: std::array::from_fn(|_| Window::default()),
+            window_start_ms: now_ms(),
+        }
+    }
+
+    fn process(&mut self, job: Job) {
+        self.expire(job.observed_at);
+        match job.class {
+            HistoricalRequestClass::None => {}
+            HistoricalRequestClass::Single => self.process_single(job),
+            HistoricalRequestClass::Batch { eligible_calls } => {
+                self.process_batch(&job.request, eligible_calls)
+            }
+        }
+    }
+
+    fn process_batch(&mut self, request: &[u8], eligible_calls: u64) {
+        let mut observed = 0u64;
+        if let Ok(serde_json::Value::Array(calls)) = serde_json::from_slice(request) {
+            for call in calls {
+                if call.get("method").and_then(|v| v.as_str()) != Some("getTransaction") {
+                    continue;
+                }
+                observed += 1;
+                let commitment = commitment_from_request(&call);
+                let window = self.window(commitment);
+                window.logical_request_count += 1;
+                window.unsupported_batch_count += 1;
+            }
+        }
+        for _ in observed..eligible_calls {
+            let window = self.window(HistoricalCommitment::Unknown);
+            window.logical_request_count += 1;
+            window.unsupported_batch_count += 1;
+        }
+    }
+
+    fn process_single(&mut self, job: Job) {
+        let request: serde_json::Value = match serde_json::from_slice(&job.request) {
+            Ok(value) => value,
+            Err(_) => {
+                self.record_error(HistoricalCommitment::Unknown, HistoricalErrorKind::Parse);
+                return;
+            }
+        };
+        let commitment = commitment_from_request(&request);
+        let Some(fingerprint) = self.fingerprint(&request) else {
+            self.record_error(commitment, HistoricalErrorKind::Parse);
+            return;
+        };
+        let outcome = parse_response(job.status, &job.response);
+        match outcome {
+            ParsedOutcome::RpcError => self.record_error(commitment, HistoricalErrorKind::Rpc),
+            ParsedOutcome::ParseError => self.record_error(commitment, HistoricalErrorKind::Parse),
+            ParsedOutcome::Null => {
+                let window = self.window(commitment);
+                window.logical_request_count += 1;
+                window.analyzed_request_count += 1;
+                window.null_count += 1;
+                self.transition(fingerprint, commitment, false, None, job.observed_at);
+            }
+            ParsedOutcome::Found(slot) => {
+                let window = self.window(commitment);
+                window.logical_request_count += 1;
+                window.analyzed_request_count += 1;
+                window.found_count += 1;
+                self.record_slot_age(commitment, slot, job.tips);
+                self.transition(fingerprint, commitment, true, slot, job.observed_at);
+            }
+        }
+    }
+
+    fn record_error(&mut self, commitment: HistoricalCommitment, kind: HistoricalErrorKind) {
+        let window = self.window(commitment);
+        window.logical_request_count += 1;
+        window.analyzed_request_count += 1;
+        match kind {
+            HistoricalErrorKind::Rpc => window.rpc_error_count += 1,
+            HistoricalErrorKind::Parse => window.parse_error_count += 1,
+        }
+    }
+
+    pub(crate) fn fingerprint(&self, request: &serde_json::Value) -> Option<Fingerprint> {
+        let object = request.as_object()?;
+        if object.get("method")?.as_str()? != "getTransaction" {
+            return None;
+        }
+        let params = object.get("params")?.as_array()?;
+        params.first()?.as_str()?;
+        let mut a = self.hash_a.build_hasher();
+        let mut b = self.hash_b.build_hasher();
+        hash_json(&serde_json::Value::String("getTransaction".into()), &mut a);
+        hash_json(&serde_json::Value::String("getTransaction".into()), &mut b);
+        hash_json(object.get("params")?, &mut a);
+        hash_json(object.get("params")?, &mut b);
+        Some(Fingerprint(a.finish(), b.finish()))
+    }
+
+    pub(crate) fn transition(
+        &mut self,
+        fingerprint: Fingerprint,
+        commitment: HistoricalCommitment,
+        found: bool,
+        _slot: Option<u64>,
+        now: Instant,
+    ) {
+        let previous = self.state.remove(&fingerprint).inspect(|entry| {
+            self.lru.remove(&(entry.last_seen_at, fingerprint));
+        });
+
+        let lifecycle = match (previous, found) {
+            (None, false) => {
+                self.record_transition(commitment, HistoricalTransition::FirstObservationNull);
+                Lifecycle::NullSeen {
+                    first_null_at: now,
+                    null_poll_count: 1,
+                }
+            }
+            (None, true) => {
+                self.record_transition(commitment, HistoricalTransition::FirstObservationFound);
+                self.window(commitment).polls_before_found_bucket_counts[0] += 1;
+                Lifecycle::Found { last_found_at: now }
+            }
+            (Some(entry), false) => match entry.lifecycle {
+                Lifecycle::NullSeen {
+                    first_null_at,
+                    null_poll_count,
+                } => {
+                    self.record_transition(commitment, HistoricalTransition::NullRepeat);
+                    Lifecycle::NullSeen {
+                        first_null_at,
+                        null_poll_count: null_poll_count.saturating_add(1),
+                    }
+                }
+                Lifecycle::Found { last_found_at } => {
+                    self.record_transition(commitment, HistoricalTransition::FoundToNullRegression);
+                    Lifecycle::Found { last_found_at }
+                }
+            },
+            (Some(entry), true) => match entry.lifecycle {
+                Lifecycle::NullSeen {
+                    first_null_at,
+                    null_poll_count,
+                } => {
+                    self.record_transition(commitment, HistoricalTransition::NullToFound);
+                    let elapsed = now.saturating_duration_since(first_null_at);
+                    let window = self.window(commitment);
+                    window.polls_before_found_bucket_counts[polls_bucket(null_poll_count)] += 1;
+                    window.time_to_found_bucket_counts
+                        [duration_bucket(elapsed, &[1, 2, 5, 15, 60])] += 1;
+                    Lifecycle::Found { last_found_at: now }
+                }
+                Lifecycle::Found { last_found_at } => {
+                    self.record_transition(commitment, HistoricalTransition::FoundRepeat);
+                    let elapsed = now.saturating_duration_since(last_found_at);
+                    self.window(commitment).found_reuse_bucket_counts[duration_bucket(
+                        elapsed,
+                        &[300, 3_600, 86_400, REUSE_EPOCH_OBSERVATION_SECS],
+                    )] += 1;
+                    Lifecycle::Found { last_found_at: now }
+                }
+            },
+        };
+
+        self.state.insert(
+            fingerprint,
+            StateEntry {
+                lifecycle,
+                commitment,
+                last_seen_at: now,
+            },
+        );
+        self.lru.insert((now, fingerprint));
+        while self.state.len() > self.capacity {
+            self.evict_oldest(HistoricalStateEvictionReason::Capacity);
+        }
+    }
+
+    fn record_transition(
+        &mut self,
+        commitment: HistoricalCommitment,
+        transition: HistoricalTransition,
+    ) {
+        let window = self.window(commitment);
+        match transition {
+            HistoricalTransition::FirstObservationFound => {
+                window.first_observation_found_count += 1
+            }
+            HistoricalTransition::FirstObservationNull => window.first_observation_null_count += 1,
+            HistoricalTransition::NullRepeat => window.null_repeat_count += 1,
+            HistoricalTransition::NullToFound => window.null_to_found_count += 1,
+            HistoricalTransition::FoundRepeat => window.found_repeat_count += 1,
+            HistoricalTransition::FoundToNullRegression => {
+                window.found_to_null_regression_count += 1
+            }
+        }
+    }
+
+    fn record_slot_age(
+        &mut self,
+        commitment: HistoricalCommitment,
+        returned_slot: Option<u64>,
+        tips: ObservedSlotTips,
+    ) {
+        let tip = match commitment {
+            HistoricalCommitment::Processed => tips.processed,
+            HistoricalCommitment::Confirmed => tips.confirmed,
+            HistoricalCommitment::Finalized => tips.finalized,
+            HistoricalCommitment::Unknown => None,
+        };
+        match (returned_slot, tip) {
+            (Some(slot), Some(tip)) if slot <= tip => {
+                let age = tip - slot;
+                self.window(commitment).slot_age_bucket_counts[slot_age_bucket(age)] += 1;
+            }
+            (Some(_), Some(_)) => {
+                self.window(commitment).slot_age_tip_behind_count += 1;
+            }
+            _ => {
+                self.window(commitment).slot_age_unknown_count += 1;
+            }
+        }
+    }
+
+    fn expire(&mut self, now: Instant) {
+        while let Some((last_seen, _)) = self.lru.first().copied() {
+            if now.saturating_duration_since(last_seen) < self.ttl {
+                break;
+            }
+            self.evict_oldest(HistoricalStateEvictionReason::Ttl);
+        }
+    }
+
+    fn evict_oldest(&mut self, reason: HistoricalStateEvictionReason) {
+        let Some((last_seen, fingerprint)) = self.lru.pop_first() else {
+            return;
+        };
+        let Some(entry) = self.state.remove(&fingerprint) else {
+            return;
+        };
+        debug_assert_eq!(entry.last_seen_at, last_seen);
+        let state = match entry.lifecycle {
+            Lifecycle::NullSeen { .. } => HistoricalState::NullSeen,
+            Lifecycle::Found { .. } => HistoricalState::Found,
+        };
+        let window = self.window(entry.commitment);
+        match reason {
+            HistoricalStateEvictionReason::Capacity => {
+                window.state_capacity_eviction_count += 1;
+                if state == HistoricalState::NullSeen {
+                    window.unresolved_null_capacity_eviction_count += 1;
+                }
+            }
+            HistoricalStateEvictionReason::Ttl => {
+                window.state_ttl_expiration_count += 1;
+                if state == HistoricalState::NullSeen {
+                    window.unresolved_null_ttl_expiration_count += 1;
+                }
+            }
+        }
+    }
+
+    fn window(&mut self, commitment: HistoricalCommitment) -> &mut Window {
+        &mut self.windows[commitment_index(commitment)]
+    }
+
+    fn flush(
+        &mut self,
+        reporter: &Arc<dyn Reporter>,
+        quality: &QualityCounters,
+        configured_capacity: usize,
+    ) {
+        let end = now_ms();
+        let dropped_logical = quality.dropped_logical.swap(0, Ordering::Relaxed);
+        let queue_full = quality.queue_full.swap(0, Ordering::Relaxed);
+        let byte_budget = quality.byte_budget.swap(0, Ordering::Relaxed);
+        let oversized = quality.oversized.swap(0, Ordering::Relaxed);
+        let resets = quality.resets.swap(0, Ordering::Relaxed);
+
+        let quality_present = dropped_logical + queue_full + byte_budget + oversized + resets > 0;
+        for (index, window) in self.windows.iter_mut().enumerate() {
+            let is_unknown = index == commitment_index(HistoricalCommitment::Unknown);
+            if window.is_empty() && !(is_unknown && quality_present) {
+                continue;
+            }
+            if is_unknown {
+                window.logical_request_count += dropped_logical;
+            }
+            let event = window.take_event(
+                commitment_for_index(index),
+                self.window_start_ms,
+                end,
+                if is_unknown { queue_full } else { 0 },
+                if is_unknown { byte_budget } else { 0 },
+                if is_unknown { oversized } else { 0 },
+                if is_unknown { resets } else { 0 },
+                self.state.len(),
+                configured_capacity,
+            );
+            reporter.emit(event);
+        }
+        self.window_start_ms = end;
+    }
+}
+
+#[derive(Default)]
+struct Window {
+    logical_request_count: u64,
+    analyzed_request_count: u64,
+    found_count: u64,
+    null_count: u64,
+    rpc_error_count: u64,
+    parse_error_count: u64,
+    first_observation_found_count: u64,
+    first_observation_null_count: u64,
+    null_repeat_count: u64,
+    null_to_found_count: u64,
+    found_repeat_count: u64,
+    found_to_null_regression_count: u64,
+    slot_age_bucket_counts: [u64; HISTORICAL_SLOT_AGE_BUCKET_COUNT],
+    slot_age_unknown_count: u64,
+    slot_age_tip_behind_count: u64,
+    polls_before_found_bucket_counts: [u64; HISTORICAL_POLLS_BEFORE_FOUND_BUCKET_COUNT],
+    time_to_found_bucket_counts: [u64; HISTORICAL_TIME_TO_FOUND_BUCKET_COUNT],
+    found_reuse_bucket_counts: [u64; HISTORICAL_FOUND_REUSE_BUCKET_COUNT],
+    unsupported_batch_count: u64,
+    state_capacity_eviction_count: u64,
+    state_ttl_expiration_count: u64,
+    unresolved_null_capacity_eviction_count: u64,
+    unresolved_null_ttl_expiration_count: u64,
+}
+
+impl Window {
+    fn is_empty(&self) -> bool {
+        self.logical_request_count == 0
+            && self.state_capacity_eviction_count == 0
+            && self.state_ttl_expiration_count == 0
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn take_event(
+        &mut self,
+        commitment: HistoricalCommitment,
+        start: u64,
+        end: u64,
+        queue_full: u64,
+        byte_budget: u64,
+        oversized: u64,
+        resets: u64,
+        entries: usize,
+        capacity: usize,
+    ) -> TelemetryEvent {
+        let window = std::mem::take(self);
+        TelemetryEvent::HistoricalGetTransactionAggregate {
+            schema_version: HISTORICAL_GET_TRANSACTION_AGGREGATE_VERSION,
+            window_start_ms: start,
+            window_end_ms: end,
+            commitment: commitment_name(commitment).to_string(),
+            logical_request_count: window.logical_request_count,
+            analyzed_request_count: window.analyzed_request_count,
+            found_count: window.found_count,
+            null_count: window.null_count,
+            rpc_error_count: window.rpc_error_count,
+            parse_error_count: window.parse_error_count,
+            first_observation_found_count: window.first_observation_found_count,
+            first_observation_null_count: window.first_observation_null_count,
+            null_repeat_count: window.null_repeat_count,
+            null_to_found_count: window.null_to_found_count,
+            found_repeat_count: window.found_repeat_count,
+            found_to_null_regression_count: window.found_to_null_regression_count,
+            slot_age_bucket_counts: Box::new(window.slot_age_bucket_counts),
+            slot_age_unknown_count: window.slot_age_unknown_count,
+            slot_age_tip_behind_count: window.slot_age_tip_behind_count,
+            polls_before_found_bucket_counts: Box::new(window.polls_before_found_bucket_counts),
+            time_to_found_bucket_counts: Box::new(window.time_to_found_bucket_counts),
+            found_reuse_bucket_counts: Box::new(window.found_reuse_bucket_counts),
+            unsupported_batch_count: window.unsupported_batch_count,
+            queue_full_drop_count: queue_full,
+            byte_budget_exhausted_drop_count: byte_budget,
+            oversized_job_drop_count: oversized,
+            state_capacity_eviction_count: window.state_capacity_eviction_count,
+            state_ttl_expiration_count: window.state_ttl_expiration_count,
+            unresolved_null_capacity_eviction_count: window.unresolved_null_capacity_eviction_count,
+            unresolved_null_ttl_expiration_count: window.unresolved_null_ttl_expiration_count,
+            state_reset_count: resets,
+            current_state_entries: entries as u64,
+            configured_state_capacity: capacity as u64,
+        }
+    }
+}
+
+pub(crate) enum ParsedOutcome {
+    Found(Option<u64>),
+    Null,
+    RpcError,
+    ParseError,
+}
+
+pub(crate) fn parse_response(status: u16, response: &[u8]) -> ParsedOutcome {
+    if !(200..300).contains(&status) {
+        return ParsedOutcome::RpcError;
+    }
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(response) else {
+        return ParsedOutcome::ParseError;
+    };
+    let Some(object) = value.as_object() else {
+        return ParsedOutcome::ParseError;
+    };
+    if object.get("error").is_some_and(|error| !error.is_null()) {
+        return ParsedOutcome::RpcError;
+    }
+    match object.get("result") {
+        Some(result) if result.is_null() => ParsedOutcome::Null,
+        Some(result) => ParsedOutcome::Found(result.get("slot").and_then(|slot| slot.as_u64())),
+        None => ParsedOutcome::ParseError,
+    }
+}
+
+fn commitment_from_request(request: &serde_json::Value) -> HistoricalCommitment {
+    let value = request
+        .get("params")
+        .and_then(|params| params.as_array())
+        .and_then(|params| params.get(1))
+        .and_then(|config| config.get("commitment"))
+        .and_then(|commitment| commitment.as_str());
+    match value {
+        Some("processed") => HistoricalCommitment::Processed,
+        Some("confirmed") => HistoricalCommitment::Confirmed,
+        Some("finalized") => HistoricalCommitment::Finalized,
+        _ => HistoricalCommitment::Unknown,
+    }
+}
+
+fn hash_json(value: &serde_json::Value, hasher: &mut impl Hasher) {
+    match value {
+        serde_json::Value::Null => hasher.write_u8(0),
+        serde_json::Value::Bool(value) => {
+            hasher.write_u8(1);
+            hasher.write_u8(*value as u8);
+        }
+        serde_json::Value::Number(value) => {
+            hasher.write_u8(2);
+            hasher.write(value.to_string().as_bytes());
+        }
+        serde_json::Value::String(value) => {
+            hasher.write_u8(3);
+            hasher.write_usize(value.len());
+            hasher.write(value.as_bytes());
+        }
+        serde_json::Value::Array(values) => {
+            hasher.write_u8(4);
+            hasher.write_usize(values.len());
+            for value in values {
+                hash_json(value, hasher);
+            }
+        }
+        serde_json::Value::Object(values) => {
+            hasher.write_u8(5);
+            hasher.write_usize(values.len());
+            let mut keys: Vec<_> = values.keys().collect();
+            keys.sort_unstable();
+            for key in keys {
+                hasher.write_usize(key.len());
+                hasher.write(key.as_bytes());
+                hash_json(&values[key], hasher);
+            }
+        }
+    }
+}
+
+fn slot_age_bucket(age: u64) -> usize {
+    [
+        149, 749, 8_999, 53_999, 215_999, 431_999, 2_159_999, 4_319_999,
+    ]
+    .iter()
+    .position(|upper| age <= *upper)
+    .unwrap_or(HISTORICAL_SLOT_AGE_BUCKET_COUNT - 1)
+}
+
+fn polls_bucket(polls: u64) -> usize {
+    match polls {
+        0 => 0,
+        1 => 1,
+        2 => 2,
+        3..=5 => 3,
+        6..=10 => 4,
+        _ => 5,
+    }
+}
+
+fn duration_bucket(duration: Duration, upper_exclusive_secs: &[u64]) -> usize {
+    upper_exclusive_secs
+        .iter()
+        .position(|upper| duration < Duration::from_secs(*upper))
+        .unwrap_or(upper_exclusive_secs.len())
+}
+
+fn commitment_index(commitment: HistoricalCommitment) -> usize {
+    match commitment {
+        HistoricalCommitment::Processed => 0,
+        HistoricalCommitment::Confirmed => 1,
+        HistoricalCommitment::Finalized => 2,
+        HistoricalCommitment::Unknown => 3,
+    }
+}
+
+fn commitment_for_index(index: usize) -> HistoricalCommitment {
+    match index {
+        0 => HistoricalCommitment::Processed,
+        1 => HistoricalCommitment::Confirmed,
+        2 => HistoricalCommitment::Finalized,
+        _ => HistoricalCommitment::Unknown,
+    }
+}
+
+fn commitment_name(commitment: HistoricalCommitment) -> &'static str {
+    match commitment {
+        HistoricalCommitment::Processed => "processed",
+        HistoricalCommitment::Confirmed => "confirmed",
+        HistoricalCommitment::Finalized => "finalized",
+        HistoricalCommitment::Unknown => "unknown",
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingReporter(Mutex<Vec<TelemetryEvent>>);
+
+    impl Reporter for RecordingReporter {
+        fn emit(&self, event: TelemetryEvent) {
+            self.0.lock().unwrap().push(event);
+        }
+
+        fn flush(&self) {}
+    }
+
+    #[test]
+    fn response_outcomes_are_classified() {
+        assert!(matches!(
+            parse_response(200, br#"{"result":null}"#),
+            ParsedOutcome::Null
+        ));
+        assert!(matches!(
+            parse_response(200, br#"{"result":{"slot":42}}"#),
+            ParsedOutcome::Found(Some(42))
+        ));
+        assert!(matches!(
+            parse_response(200, br#"{"error":{"code":-1}}"#),
+            ParsedOutcome::RpcError
+        ));
+        assert!(matches!(
+            parse_response(200, b"bad"),
+            ParsedOutcome::ParseError
+        ));
+    }
+
+    #[test]
+    fn fingerprint_excludes_id_and_canonicalizes_object_order() {
+        let core = AnalyzerCore::new(10, 60);
+        let a = serde_json::json!({
+            "id": 1,
+            "method": "getTransaction",
+            "params": ["signature", {"encoding":"json", "commitment":"confirmed"}]
+        });
+        let b = serde_json::json!({
+            "id": "different",
+            "method": "getTransaction",
+            "params": ["signature", {"commitment":"confirmed", "encoding":"json"}]
+        });
+        assert_eq!(core.fingerprint(&a), core.fingerprint(&b));
+
+        let c = serde_json::json!({
+            "method": "getTransaction",
+            "params": ["signature", {"commitment":"finalized", "encoding":"json"}]
+        });
+        assert_ne!(core.fingerprint(&a), core.fingerprint(&c));
+    }
+
+    #[test]
+    fn bucket_boundaries_match_schema() {
+        assert_eq!(slot_age_bucket(149), 0);
+        assert_eq!(slot_age_bucket(150), 1);
+        assert_eq!(slot_age_bucket(4_320_000), 8);
+        assert_eq!(polls_bucket(0), 0);
+        assert_eq!(polls_bucket(3), 3);
+        assert_eq!(polls_bucket(11), 5);
+        assert_eq!(duration_bucket(Duration::from_millis(999), &[1, 2]), 0);
+        assert_eq!(duration_bucket(Duration::from_secs(1), &[1, 2]), 1);
+    }
+
+    #[test]
+    fn lifecycle_transitions_and_regression_preserve_last_found_time() {
+        let mut core = AnalyzerCore::new(10, 10_000);
+        let fingerprint = Fingerprint(1, 2);
+        let commitment = HistoricalCommitment::Confirmed;
+        let start = Instant::now();
+
+        core.transition(fingerprint, commitment, false, None, start);
+        core.transition(
+            fingerprint,
+            commitment,
+            false,
+            None,
+            start + Duration::from_secs(1),
+        );
+        core.transition(
+            fingerprint,
+            commitment,
+            true,
+            Some(1),
+            start + Duration::from_secs(2),
+        );
+        core.transition(
+            fingerprint,
+            commitment,
+            false,
+            None,
+            start + Duration::from_secs(402),
+        );
+        core.transition(
+            fingerprint,
+            commitment,
+            true,
+            Some(1),
+            start + Duration::from_secs(502),
+        );
+
+        let window = &core.windows[commitment_index(commitment)];
+        assert_eq!(window.first_observation_null_count, 1);
+        assert_eq!(window.null_repeat_count, 1);
+        assert_eq!(window.null_to_found_count, 1);
+        assert_eq!(window.found_to_null_regression_count, 1);
+        assert_eq!(window.found_repeat_count, 1);
+        assert_eq!(window.polls_before_found_bucket_counts[2], 1);
+        assert_eq!(window.found_reuse_bucket_counts[1], 1);
+    }
+
+    #[test]
+    fn capacity_and_ttl_evictions_count_unresolved_nulls() {
+        let start = Instant::now();
+        let mut core = AnalyzerCore::new(1, 10);
+        core.transition(
+            Fingerprint(1, 1),
+            HistoricalCommitment::Processed,
+            false,
+            None,
+            start,
+        );
+        core.transition(
+            Fingerprint(2, 2),
+            HistoricalCommitment::Processed,
+            true,
+            None,
+            start + Duration::from_secs(1),
+        );
+        let window = &core.windows[commitment_index(HistoricalCommitment::Processed)];
+        assert_eq!(window.state_capacity_eviction_count, 1);
+        assert_eq!(window.unresolved_null_capacity_eviction_count, 1);
+
+        let mut ttl_core = AnalyzerCore::new(2, 10);
+        ttl_core.transition(
+            Fingerprint(3, 3),
+            HistoricalCommitment::Finalized,
+            false,
+            None,
+            start,
+        );
+        ttl_core.expire(start + Duration::from_secs(10));
+        let window = &ttl_core.windows[commitment_index(HistoricalCommitment::Finalized)];
+        assert_eq!(window.state_ttl_expiration_count, 1);
+        assert_eq!(window.unresolved_null_ttl_expiration_count, 1);
+        assert!(ttl_core.state.is_empty());
+    }
+
+    #[test]
+    fn aggregate_flush_emits_only_counts() {
+        let mut core = AnalyzerCore::new(10, 60);
+        let reporter = Arc::new(RecordingReporter::default());
+        let reporter_trait: Arc<dyn Reporter> = reporter.clone();
+        let quality = QualityCounters::default();
+        quality.resets.store(1, Ordering::Relaxed);
+        core.transition(
+            Fingerprint(9, 9),
+            HistoricalCommitment::Processed,
+            true,
+            None,
+            Instant::now(),
+        );
+        core.window(HistoricalCommitment::Processed)
+            .logical_request_count = 1;
+        core.flush(&reporter_trait, &quality, 10);
+
+        let events = reporter.0.lock().unwrap();
+        assert_eq!(events.len(), 2); // processed data plus unknown reset quality
+        let json = serde_json::to_string(&*events).unwrap();
+        assert!(!json.contains("Fingerprint"));
+        assert!(!json.contains("signature"));
+        assert!(json.contains("historical_get_transaction_aggregate"));
+    }
+}

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -4,8 +4,12 @@
 //!
 //! Each test gets its own tokio runtime; spawned tasks are aborted on drop.
 use crate::{
-    config::{Config, HealthConfig, ProviderConfig, RoutingConfig, RoutingStrategy, ServerConfig},
+    config::{
+        Config, HealthConfig, HistoricalAnalyticsConfig, ProviderConfig, RoutingConfig,
+        RoutingStrategy, ServerConfig,
+    },
     proxy::{build_router, ProxyState},
+    telemetry::{Reporter, TelemetryEvent},
 };
 use axum::{
     body::Body,
@@ -18,7 +22,7 @@ use http_body_util::BodyExt;
 use serde_json::{json, Value};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc,
+    Arc, Mutex,
 };
 use std::time::Duration;
 use tower::ServiceExt;
@@ -94,6 +98,7 @@ fn test_config(
             })
             .collect(),
         reporting: None,
+        historical_analytics: None,
     }
 }
 
@@ -157,7 +162,137 @@ fn rpc_error_response(code: i64, msg: &'static str) -> axum::Json<Value> {
     }))
 }
 
+/// Captures emitted telemetry so tests can assert on aggregates. Historical
+/// analysis has no Prometheus surface — the event is the only observable.
+#[derive(Default)]
+struct RecordingReporter(Mutex<Vec<TelemetryEvent>>);
+
+impl Reporter for RecordingReporter {
+    fn emit(&self, event: TelemetryEvent) {
+        self.0.lock().unwrap().push(event);
+    }
+
+    fn flush(&self) {}
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn historical_get_transaction_lifecycle_is_counted_once_and_body_is_unchanged() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mock_calls = calls.clone();
+    let mock = Router::new().route(
+        "/",
+        post(move |body: axum::body::Bytes| {
+            let request: Value = serde_json::from_slice(&body).unwrap();
+            let is_transaction = request["method"] == "getTransaction";
+            let call = if is_transaction {
+                mock_calls.fetch_add(1, Ordering::Relaxed)
+            } else {
+                0
+            };
+            async move {
+                let result = if !is_transaction {
+                    json!(1_000)
+                } else if call < 2 {
+                    Value::Null
+                } else {
+                    json!({"slot": 900, "meta": null, "transaction": {}})
+                };
+                axum::Json(json!({"jsonrpc":"2.0", "result":result, "id":call + 1}))
+            }
+        }),
+    );
+    let (url, _abort) = start_mock(mock).await;
+    let mut cfg = test_config(&[("a", &url)], RoutingStrategy::FailoverOrdered, 0, 5);
+    cfg.historical_analytics = Some(HistoricalAnalyticsConfig {
+        queue_capacity: 8,
+        max_queued_bytes: 65_536,
+        max_job_bytes: 16_384,
+        state_capacity: 100,
+        state_ttl_secs: 60,
+        flush_interval_ms: 60_000,
+    });
+    let reporter = Arc::new(RecordingReporter::default());
+    let state = ProxyState::new_with_reporter(cfg, reporter.clone());
+    state.monitor.update_slot("a", 1_000);
+    let router = build_router(state.clone());
+
+    for id in 1..=4 {
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "getTransaction",
+            "params": ["private-signature", {"commitment": "processed", "encoding": "json"}]
+        })
+        .to_string();
+        let (status, body) = proxy_request(router.clone(), &request).await;
+        assert_eq!(status, StatusCode::OK);
+        if id <= 2 {
+            assert!(body["result"].is_null());
+        } else {
+            assert_eq!(body["result"]["slot"], 900);
+        }
+    }
+
+    state.flush_historical_analytics().await;
+
+    // One aggregate per commitment per window; `processed` carries this test's
+    // four logical requests. Serialized form must never leak the signature.
+    let events = reporter.0.lock().unwrap();
+    let json = serde_json::to_string(&*events).unwrap();
+    assert!(
+        !json.contains("private-signature"),
+        "signature leaked: {json}"
+    );
+
+    let aggregate = events
+        .iter()
+        .find(|event| {
+            matches!(
+                event,
+                TelemetryEvent::HistoricalGetTransactionAggregate { commitment, .. }
+                    if commitment == "processed"
+            )
+        })
+        .expect("expected a processed-commitment aggregate");
+
+    let TelemetryEvent::HistoricalGetTransactionAggregate {
+        logical_request_count,
+        analyzed_request_count,
+        found_count,
+        null_count,
+        first_observation_null_count,
+        null_repeat_count,
+        null_to_found_count,
+        found_repeat_count,
+        found_to_null_regression_count,
+        polls_before_found_bucket_counts,
+        slot_age_bucket_counts,
+        ..
+    } = aggregate
+    else {
+        unreachable!()
+    };
+
+    // Four client-visible requests, each analyzed exactly once: null, null,
+    // found, found. Provider retries must not add logical samples.
+    assert_eq!(*logical_request_count, 4);
+    assert_eq!(*analyzed_request_count, 4);
+    assert_eq!(*null_count, 2);
+    assert_eq!(*found_count, 2);
+    assert_eq!(*first_observation_null_count, 1);
+    assert_eq!(*null_repeat_count, 1);
+    assert_eq!(*null_to_found_count, 1);
+    assert_eq!(*found_repeat_count, 1);
+    assert_eq!(*found_to_null_regression_count, 0);
+    // Two null polls preceded the first found result -> the "2" bucket.
+    assert_eq!(polls_before_found_bucket_counts[2], 1);
+    // Tip 1000 - slot 900 = 100 slots -> the 0-149 bucket, both found samples.
+    assert_eq!(slot_age_bucket_counts[0], 2);
+
+    assert_eq!(calls.load(Ordering::Relaxed), 4);
+}
 
 #[tokio::test]
 async fn transaction_sequential_acceptance_and_rejection_are_counted_once() {
@@ -630,6 +765,7 @@ async fn circuit_recovers_traffic_resumes() {
             },
         ],
         reporting: None,
+        historical_analytics: None,
     };
     let state = ProxyState::new(cfg);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod health;
+mod historical;
 mod metrics;
 mod proxy;
 mod router;
@@ -192,6 +193,8 @@ async fn run(config_path: PathBuf) -> Result<()> {
             .await?;
     }
 
+    // Emit accepted historical aggregates before the reporter's final flush.
+    state.flush_historical_analytics().await;
     // Ensure queued transaction decodes reach the reporter before its final flush.
     state.flush_transaction_analytics().await;
     // Flush any buffered telemetry before exiting.
@@ -414,14 +417,18 @@ async fn watch_config(
         };
 
         // Snapshot old config for diffing (clone out so we don't hold the lock).
-        let (old_providers, old_server) = {
+        let (old_providers, old_server, old_historical_analytics) = {
             let old = config.read();
             let providers: HashMap<String, crate::config::ProviderConfig> = old
                 .providers
                 .iter()
                 .map(|p| (p.name.clone(), p.clone()))
                 .collect();
-            (providers, old.server.clone())
+            (
+                providers,
+                old.server.clone(),
+                old.historical_analytics.clone(),
+            )
         };
 
         // pool_max_idle_per_host feeds every outbound client, so a change forces
@@ -505,6 +512,9 @@ async fn watch_config(
                 "a restart-only server setting changed (listen / metrics_listen / \
                  listen_backlog / worker_threads) — restart required to take effect"
             );
+        }
+        if old_historical_analytics != new_config.historical_analytics {
+            warn!("historical_analytics settings changed; restart required to take effect");
         }
 
         *config.write() = Arc::new(new_config);

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,5 +1,6 @@
 use crate::config::{Config, ProviderConfig};
 use crate::health::{CircuitState, CommitmentHealth, HealthMonitor};
+use crate::historical::{HistoricalAnalytics, HistoricalRequestClass};
 use crate::metrics::Metrics;
 use crate::router::{
     extract_rpc_error_code, is_client_error, is_retryable_http, is_retryable_rpc_code, route,
@@ -65,6 +66,7 @@ pub struct ProxyState {
     pub metrics: Metrics,
     pub reporter: Arc<dyn Reporter>,
     tx_analytics: TransactionAnalytics,
+    historical_analytics: Option<HistoricalAnalytics>,
 }
 
 impl ProxyState {
@@ -81,6 +83,10 @@ impl ProxyState {
         let monitor = HealthMonitor::new(&config.providers, config.health.clone(), metrics.clone());
         monitor.start(clients.clone(), config.providers.clone());
         let tx_analytics = TransactionAnalytics::new(metrics.clone(), reporter.clone());
+        let historical_analytics = config
+            .historical_analytics
+            .clone()
+            .map(|analytics_config| HistoricalAnalytics::new(analytics_config, reporter.clone()));
         Self {
             config: Arc::new(parking_lot::RwLock::new(Arc::new(config))),
             clients,
@@ -88,6 +94,7 @@ impl ProxyState {
             metrics,
             reporter,
             tx_analytics,
+            historical_analytics,
         }
     }
 
@@ -106,6 +113,12 @@ impl ProxyState {
     /// been processed. Used during graceful shutdown before flushing telemetry.
     pub async fn flush_transaction_analytics(&self) {
         self.tx_analytics.flush().await;
+    }
+
+    pub async fn flush_historical_analytics(&self) {
+        if let Some(analytics) = &self.historical_analytics {
+            analytics.flush().await;
+        }
     }
 
     fn client_for(&self, name: &str) -> Option<Arc<Client>> {
@@ -431,11 +444,18 @@ async fn handle_rpc(State(state): State<ProxyState>, headers: HeaderMap, body: B
     let request_id = Uuid::new_v4();
     // `call_count` is the number of JSON-RPC calls (batch size) — used to weight
     // metrics/telemetry so a 1000-call batch is billed as 1000, not 1.
-    let (method, call_count, transaction_request) = classify_request(&body)
-        .unwrap_or_else(|| ("unknown".to_string(), 1, TransactionRequest::None));
+    let (method, call_count, transaction_request, historical_request) = classify_request(&body)
+        .unwrap_or_else(|| {
+            (
+                "unknown".to_string(),
+                1,
+                TransactionRequest::None,
+                HistoricalRequestClass::None,
+            )
+        });
 
     let config = state.current_config();
-    let snapshots = state.monitor.snapshots();
+    let (snapshots, observed_tips) = state.monitor.snapshots_with_tips();
     let decision = route(
         &method,
         &snapshots,
@@ -452,6 +472,8 @@ async fn handle_rpc(State(state): State<ProxyState>, headers: HeaderMap, body: B
         request_id,
         count: call_count,
         transaction_request,
+        historical_request,
+        observed_tips,
     };
 
     // A degraded decision means no provider was routable (all circuit-open
@@ -477,6 +499,27 @@ struct RequestCtx<'a> {
     /// JSON-RPC call count (batch size) — weights metrics/telemetry.
     count: u64,
     transaction_request: TransactionRequest,
+    historical_request: HistoricalRequestClass,
+    observed_tips: crate::health::ObservedSlotTips,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finish_analytics(
+    state: &ProxyState,
+    transaction_request: TransactionRequest,
+    historical_request: HistoricalRequestClass,
+    request: &Bytes,
+    response: &Bytes,
+    status: u16,
+    tips: crate::health::ObservedSlotTips,
+    acknowledging_provider: Option<Arc<str>>,
+) {
+    state
+        .tx_analytics
+        .finish(transaction_request, request, acknowledging_provider);
+    if let Some(analytics) = &state.historical_analytics {
+        analytics.finish(historical_request, request, response, status, tips);
+    }
 }
 
 /// Result of one provider forward: (provider name, Ok(status, body) | Err(msg), latency_ms).
@@ -498,6 +541,8 @@ async fn sequential(
         request_id,
         count,
         transaction_request,
+        historical_request,
+        observed_tips,
     } = ctx;
     let max_attempts = (config.routing.max_retries + 1).min(providers.len());
     // Count of real forwards issued. Providers skipped before dispatch (missing
@@ -603,13 +648,22 @@ async fn sequential(
                         "upstream non-2xx, passing status through"
                     );
                     recorder.record(method, name, outcome, latency_ms, count);
+                    finish_analytics(
+                        state,
+                        transaction_request,
+                        historical_request,
+                        body,
+                        &bytes,
+                        status,
+                        observed_tips,
+                        None,
+                    );
                     let response = (
                         StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
                         [("content-type", "application/json")],
                         bytes,
                     )
                         .into_response();
-                    state.tx_analytics.finish(transaction_request, body, None);
                     return response;
                 }
 
@@ -630,13 +684,22 @@ async fn sequential(
                 }
                 if has_rpc_error(&bytes) {
                     recorder.record(method, name, Outcome::ProviderError, latency_ms, count);
+                    finish_analytics(
+                        state,
+                        transaction_request,
+                        historical_request,
+                        body,
+                        &bytes,
+                        StatusCode::OK.as_u16(),
+                        observed_tips,
+                        None,
+                    );
                     let response = (
                         StatusCode::OK,
                         [("content-type", "application/json")],
                         bytes,
                     )
                         .into_response();
-                    state.tx_analytics.finish(transaction_request, body, None);
                     return response;
                 }
                 info!(
@@ -648,15 +711,22 @@ async fn sequential(
                     "request ok"
                 );
                 recorder.record(method, name, Outcome::Ok, latency_ms, count);
+                finish_analytics(
+                    state,
+                    transaction_request,
+                    historical_request,
+                    body,
+                    &bytes,
+                    StatusCode::OK.as_u16(),
+                    observed_tips,
+                    Some(name.clone()),
+                );
                 let response = (
                     StatusCode::OK,
                     [("content-type", "application/json")],
                     bytes,
                 )
                     .into_response();
-                state
-                    .tx_analytics
-                    .finish(transaction_request, body, Some(name.clone()));
                 return response;
             }
             Err(e) => {
@@ -675,8 +745,18 @@ async fn sequential(
     }
 
     error!(%request_id, method, "all providers failed");
-    state.tx_analytics.finish(transaction_request, body, None);
-    json_error_response(StatusCode::BAD_GATEWAY, -32603, "all providers failed")
+    let response_body = json_error_body(-32603, "all providers failed");
+    finish_analytics(
+        state,
+        transaction_request,
+        historical_request,
+        body,
+        &response_body,
+        StatusCode::BAD_GATEWAY.as_u16(),
+        observed_tips,
+        None,
+    );
+    json_response(StatusCode::BAD_GATEWAY, response_body)
 }
 
 // ── Broadcast (writes + parallel race) ────────────────────────────────────────
@@ -695,14 +775,22 @@ async fn broadcast(
         request_id,
         count,
         transaction_request,
+        historical_request,
+        observed_tips,
     } = ctx;
     if providers.is_empty() {
-        state.tx_analytics.finish(transaction_request, body, None);
-        return json_error_response(
-            StatusCode::SERVICE_UNAVAILABLE,
-            -32603,
-            "no providers available",
+        let response_body = json_error_body(-32603, "no providers available");
+        finish_analytics(
+            state,
+            transaction_request,
+            historical_request,
+            body,
+            &response_body,
+            StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+            observed_tips,
+            None,
         );
+        return json_response(StatusCode::SERVICE_UNAVAILABLE, response_body);
     }
 
     let mut set: JoinSet<ForwardOutcome> = JoinSet::new();
@@ -775,15 +863,22 @@ async fn broadcast(
                         "broadcast first success"
                     );
                     spawn_straggler_drain(recorder, method, request_id, count, set);
+                    finish_analytics(
+                        state,
+                        transaction_request,
+                        historical_request,
+                        body,
+                        &bytes,
+                        StatusCode::OK.as_u16(),
+                        observed_tips,
+                        Some(name),
+                    );
                     let response = (
                         StatusCode::OK,
                         [("content-type", "application/json")],
                         bytes,
                     )
                         .into_response();
-                    state
-                        .tx_analytics
-                        .finish(transaction_request, body, Some(name));
                     return response;
                 }
                 let rpc_code = extract_rpc_error_code(&bytes);
@@ -809,18 +904,37 @@ async fn broadcast(
     // rather than masking it as a generic -32603.
     if let Some((status, bytes, _)) = best_error {
         error!(%request_id, method, "all broadcast providers failed; returning upstream error");
+        finish_analytics(
+            state,
+            transaction_request,
+            historical_request,
+            body,
+            &bytes,
+            status,
+            observed_tips,
+            None,
+        );
         let response = (
             StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
             [("content-type", "application/json")],
             bytes,
         )
             .into_response();
-        state.tx_analytics.finish(transaction_request, body, None);
         return response;
     }
     error!(%request_id, method, "all broadcast providers failed");
-    state.tx_analytics.finish(transaction_request, body, None);
-    json_error_response(StatusCode::BAD_GATEWAY, -32603, "all providers failed")
+    let response_body = json_error_body(-32603, "all providers failed");
+    finish_analytics(
+        state,
+        transaction_request,
+        historical_request,
+        body,
+        &response_body,
+        StatusCode::BAD_GATEWAY.as_u16(),
+        observed_tips,
+        None,
+    );
+    json_response(StatusCode::BAD_GATEWAY, response_body)
 }
 
 /// A broadcast leg counts as a success only on HTTP 2xx *and* a body with no
@@ -949,10 +1063,12 @@ const MAX_METHOD_LABEL_LEN: usize = 128;
 /// count weights metrics/telemetry so that batch is billed as its true volume.
 #[allow(dead_code)] // Kept as a focused benchmark and unit-test entry point.
 pub fn extract_method(body: &[u8]) -> Option<(String, u64)> {
-    classify_request(body).map(|(method, count, _)| (method, count))
+    classify_request(body).map(|(method, count, _, _)| (method, count))
 }
 
-fn classify_request(body: &[u8]) -> Option<(String, u64, TransactionRequest)> {
+fn classify_request(
+    body: &[u8],
+) -> Option<(String, u64, TransactionRequest, HistoricalRequestClass)> {
     let first = body.iter().find(|&&b| !b.is_ascii_whitespace())?;
     if *first == b'{' {
         // Single request: parse only the method field, skip everything else.
@@ -966,6 +1082,11 @@ fn classify_request(body: &[u8]) -> Option<(String, u64, TransactionRequest)> {
                 } else {
                     TransactionRequest::None
                 },
+                if m == "getTransaction" {
+                    HistoricalRequestClass::Single
+                } else {
+                    HistoricalRequestClass::None
+                },
             )
         });
     }
@@ -978,9 +1099,11 @@ fn classify_request(body: &[u8]) -> Option<(String, u64, TransactionRequest)> {
     let mut uniques: Vec<&str> = Vec::new();
     let mut calls: u64 = 0;
     let mut contains_send_transaction = false;
+    let mut historical_calls = 0u64;
     for m in arr.iter().filter_map(|r| r.method) {
         calls += 1;
         contains_send_transaction |= m == "sendTransaction";
+        historical_calls += u64::from(m == "getTransaction");
         if !uniques.contains(&m) {
             uniques.push(m);
         }
@@ -1008,16 +1131,28 @@ fn classify_request(body: &[u8]) -> Option<(String, u64, TransactionRequest)> {
         } else {
             TransactionRequest::None
         },
+        if historical_calls > 0 {
+            HistoricalRequestClass::Batch {
+                eligible_calls: historical_calls,
+            }
+        } else {
+            HistoricalRequestClass::None
+        },
     ))
 }
 
-fn json_error_response(status: StatusCode, code: i64, message: &str) -> Response {
-    let body = serde_json::json!({
-        "jsonrpc": "2.0",
-        "error": { "code": code, "message": message },
-        "id": null,
-    })
-    .to_string();
+fn json_error_body(code: i64, message: &str) -> Bytes {
+    Bytes::from(
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "error": { "code": code, "message": message },
+            "id": null,
+        })
+        .to_string(),
+    )
+}
+
+fn json_response(status: StatusCode, body: Bytes) -> Response {
     (status, [("content-type", "application/json")], body).into_response()
 }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -12,6 +12,13 @@ use tracing::{debug, warn};
 
 // ── Event types ───────────────────────────────────────────────────────────────
 
+/// Schema version for `HistoricalGetTransactionAggregate`, including array order.
+pub const HISTORICAL_GET_TRANSACTION_AGGREGATE_VERSION: u32 = 1;
+pub const HISTORICAL_SLOT_AGE_BUCKET_COUNT: usize = 9;
+pub const HISTORICAL_POLLS_BEFORE_FOUND_BUCKET_COUNT: usize = 6;
+pub const HISTORICAL_TIME_TO_FOUND_BUCKET_COUNT: usize = 6;
+pub const HISTORICAL_FOUND_REUSE_BUCKET_COUNT: usize = 5;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TelemetryEvent {
@@ -53,6 +60,55 @@ pub enum TelemetryEvent {
         requested_priority_fee_lamports_p50: u64,
         requested_priority_fee_lamports_p90: u64,
         requested_priority_fee_lamports_p95: u64,
+    },
+    HistoricalGetTransactionAggregate {
+        /// Defines the meaning and boundaries of every fixed-size bucket array.
+        schema_version: u32,
+        window_start_ms: u64,
+        window_end_ms: u64,
+        /// "processed" | "confirmed" | "finalized" | "unknown"
+        commitment: String,
+        logical_request_count: u64,
+        analyzed_request_count: u64,
+        found_count: u64,
+        null_count: u64,
+        rpc_error_count: u64,
+        parse_error_count: u64,
+        first_observation_found_count: u64,
+        first_observation_null_count: u64,
+        null_repeat_count: u64,
+        null_to_found_count: u64,
+        found_repeat_count: u64,
+        found_to_null_regression_count: u64,
+        /// Counts for 0-149, 150-749, 750-8,999, 9,000-53,999,
+        /// 54,000-215,999, 216,000-431,999, 432,000-2,159,999,
+        /// 2,160,000-4,319,999, and 4,320,000+ slots, in that order.
+        /// Boxed so this variant does not dominate the size of every
+        /// `TelemetryEvent`; a `Box<[u64; N]>` serializes as a plain array, so
+        /// the wire format is unchanged. One allocation per flush window.
+        slot_age_bucket_counts: Box<[u64; HISTORICAL_SLOT_AGE_BUCKET_COUNT]>,
+        slot_age_unknown_count: u64,
+        slot_age_tip_behind_count: u64,
+        /// Counts for 0, 1, 2, 3-5, 6-10, and 11+ null polls.
+        polls_before_found_bucket_counts: Box<[u64; HISTORICAL_POLLS_BEFORE_FOUND_BUCKET_COUNT]>,
+        /// Counts for <1s, <2s, <5s, <15s, <60s, and >=60s.
+        time_to_found_bucket_counts: Box<[u64; HISTORICAL_TIME_TO_FOUND_BUCKET_COUNT]>,
+        /// Counts for <300s, 300-3,599s, 3,600-86,399s, 86,400-172,799s,
+        /// and 172,800s or later.
+        found_reuse_bucket_counts: Box<[u64; HISTORICAL_FOUND_REUSE_BUCKET_COUNT]>,
+        unsupported_batch_count: u64,
+        queue_full_drop_count: u64,
+        byte_budget_exhausted_drop_count: u64,
+        oversized_job_drop_count: u64,
+        state_capacity_eviction_count: u64,
+        state_ttl_expiration_count: u64,
+        /// Subset of capacity evictions whose state was an unresolved null.
+        unresolved_null_capacity_eviction_count: u64,
+        /// Subset of TTL expirations whose state was an unresolved null.
+        unresolved_null_ttl_expiration_count: u64,
+        state_reset_count: u64,
+        current_state_entries: u64,
+        configured_state_capacity: u64,
     },
     ProviderHealth {
         provider: String,
@@ -662,6 +718,80 @@ mod tests {
         let json = serde_json::to_value(&ev).unwrap();
         assert_eq!(json["type"], "request_aggregate");
         assert_eq!(json["count"], 5000);
+    }
+
+    #[test]
+    fn historical_get_transaction_aggregate_serializes_schema() {
+        let ev = TelemetryEvent::HistoricalGetTransactionAggregate {
+            schema_version: HISTORICAL_GET_TRANSACTION_AGGREGATE_VERSION,
+            window_start_ms: 1_000,
+            window_end_ms: 61_000,
+            commitment: "confirmed".into(),
+            logical_request_count: 100,
+            analyzed_request_count: 95,
+            found_count: 40,
+            null_count: 50,
+            rpc_error_count: 3,
+            parse_error_count: 2,
+            first_observation_found_count: 20,
+            first_observation_null_count: 25,
+            null_repeat_count: 25,
+            null_to_found_count: 10,
+            found_repeat_count: 10,
+            found_to_null_regression_count: 1,
+            slot_age_bucket_counts: Box::new([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            slot_age_unknown_count: 2,
+            slot_age_tip_behind_count: 1,
+            polls_before_found_bucket_counts: Box::new([10, 9, 8, 7, 6, 5]),
+            time_to_found_bucket_counts: Box::new([1, 3, 5, 7, 9, 11]),
+            found_reuse_bucket_counts: Box::new([2, 4, 6, 8, 10]),
+            unsupported_batch_count: 2,
+            queue_full_drop_count: 1,
+            byte_budget_exhausted_drop_count: 2,
+            oversized_job_drop_count: 3,
+            state_capacity_eviction_count: 4,
+            state_ttl_expiration_count: 5,
+            unresolved_null_capacity_eviction_count: 2,
+            unresolved_null_ttl_expiration_count: 3,
+            state_reset_count: 1,
+            current_state_entries: 12_345,
+            configured_state_capacity: 250_000,
+        };
+
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["type"], "historical_get_transaction_aggregate");
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(json["commitment"], "confirmed");
+        assert_eq!(json["logical_request_count"], 100);
+        assert_eq!(
+            json["slot_age_bucket_counts"],
+            serde_json::json!([1, 2, 3, 4, 5, 6, 7, 8, 9])
+        );
+        assert_eq!(
+            json["polls_before_found_bucket_counts"],
+            serde_json::json!([10, 9, 8, 7, 6, 5])
+        );
+        assert_eq!(
+            json["time_to_found_bucket_counts"],
+            serde_json::json!([1, 3, 5, 7, 9, 11])
+        );
+        assert_eq!(
+            json["found_reuse_bucket_counts"],
+            serde_json::json!([2, 4, 6, 8, 10])
+        );
+        assert_eq!(json["slot_age_unknown_count"], 2);
+        assert_eq!(json["slot_age_tip_behind_count"], 1);
+        assert_eq!(json["configured_state_capacity"], 250_000);
+
+        let decoded: TelemetryEvent = serde_json::from_value(json).unwrap();
+        assert!(matches!(
+            decoded,
+            TelemetryEvent::HistoricalGetTransactionAggregate {
+                schema_version: HISTORICAL_GET_TRANSACTION_AGGREGATE_VERSION,
+                configured_state_capacity: 250_000,
+                ..
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Adds bounded, opt-in telemetry that measures how far back in history a workload actually reaches, so retention and caching decisions can be made from measurements rather than assumptions.

The analyzer distinguishes repeated null polling (submit-then-poll amplification) from reuse of a successful response (the real positive-cache signal), and reports returned transaction age in slots relative to the observed per-commitment network tip.

Scope is getTransaction only. Additional historical methods, batch correlation, and any cache experiment are deliberately out of scope until this has demonstrated its runtime cost.

### Design notes:

- Disabled by default. Absent config spawns no worker, allocates no state, and reduces the completion path to an Option check (~300 ps).
- Nothing is parsed on the request task. The enabled hot path is a bounds check, a semaphore permit, two Bytes clones, and a try_send (~69 ns).
- The queue is bounded by both job count and bytes, since getBlock and some transaction responses are large. Saturation drops telemetry rather than delaying or failing RPC requests; drops are counted by reason.
- Fingerprint state is capacity- and TTL-bounded with LRU eviction. Evictions and expirations are counted separately, and unresolved nulls among them are tracked, so a report can weigh its own confidence.
- Request fingerprints use a process-local keyed hasher. Fingerprints are never exported and a restart resets the state, which is counted.

Delivery is via the versioned historical_get_transaction_aggregate telemetry event only; there is no Prometheus surface, as this is a hosted-dashboard feature. Consequently [historical_analytics] requires [reporting] and is rejected without it, rather than silently running an analyzer that reports nowhere.